### PR TITLE
MYCE-223 fix: 이미지 업로드 시 환경별 CDN URL 변환 로직 개선

### DIFF
--- a/src/api/userProfileService.ts
+++ b/src/api/userProfileService.ts
@@ -175,21 +175,22 @@ export const UserProfileService = {
 
       console.log("이미지 업로드 응답:", response.data);
 
-      // 백엔드에서 이미지 URL을 직접 반환하므로 그대로 사용
-      // URL이 상대 경로인 경우 baseURL과 결합
+      // 백엔드에서 반환된 URL을 환경에 맞는 CDN URL로 변환
       let imageUrl = response.data;
+
+      // mock-gcp-bucket URL을 실제 CDN URL로 변환
+      if (imageUrl && imageUrl.includes("mock-gcp-bucket")) {
+        imageUrl = convertMockUrlToCdnUrl(imageUrl);
+        console.log("업로드 후 CDN URL로 변환됨:", imageUrl);
+      }
+
+      // URL이 상대 경로인 경우 baseURL과 결합
       if (imageUrl && !imageUrl.startsWith("http")) {
         const baseURL =
           process.env.REACT_APP_API_URL || "https://localhost:8443";
         imageUrl = `${baseURL}${
           imageUrl.startsWith("/") ? "" : "/"
         }${imageUrl}`;
-      }
-
-      // mock-gcp-bucket URL을 실제 CDN URL로 변환
-      if (imageUrl && imageUrl.includes("mock-gcp-bucket")) {
-        imageUrl = convertMockUrlToCdnUrl(imageUrl);
-        console.log("업로드 후 CDN URL로 변환됨:", imageUrl);
       }
 
       console.log("최종 이미지 URL:", imageUrl);

--- a/src/utils/common/images.ts
+++ b/src/utils/common/images.ts
@@ -32,10 +32,8 @@ export const convertMockUrlToCdnUrl = (url: string): string => {
 
   // mock-gcp-bucket URL을 실제 CDN URL로 변환
   if (url.includes("mock-gcp-bucket")) {
-    return url.replace(
-      "https://mock-gcp-bucket",
-      "https://dev.cdn-feedshop.store"
-    );
+    const baseUrl = getImageBaseUrl();
+    return url.replace("https://mock-gcp-bucket", baseUrl);
   }
 
   return url;


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->

이미지 업로드 시 mock-gcp-bucket URL을 환경별로 올바른 CDN URL로 변환하는 로직을 개선했습니다.


**Type**
- [ ] ✨ Feature
- [x] 🐛 Bug Fix
- [x] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore


---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->

환경별 CDN URL 동적 처리: convertMockUrlToCdnUrl 함수에서 하드코딩된 개발 환경 URL을 환경별 동적 URL 선택으로 변경
이미지 업로드 처리 순서 개선: mock URL 변환을 상대 경로 처리보다 먼저 수행하도록 순서 변경
프로필 이미지 업로드 로직 강화: 백엔드에서 반환된 mock URL을 환경에 맞는 실제 CDN URL로 정확히 변환

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

DB 저장 URL 오류: 이미지 업로드 시 https://mock-gcp-bucket/... URL이 DB에 저장되어 실제 이미지가 표시되지 않는 문제
환경별 URL 불일치: 개발 환경에서는 https://dev.cdn-feedshop.store/..., 운영 환경에서는 https://cdn-feedshop.store/...로 저장되어야 하는데 하드코딩으로 인한 오류
이미지 표시 실패: 잘못된 URL로 인해 프로필 이미지가 로드되지 않는 사용자 경험 문제

---

## 🔧 How (구현 방법)
### 주요 변경사항
1. convertMockUrlToCdnUrl 함수 개선
// 이전 (하드코딩)
if (url.includes("mock-gcp-bucket")) {
  return url.replace(
    "https://mock-gcp-bucket",
    "https://dev.cdn-feedshop.store"  // ❌ 개발 환경만 고정
  );
}

// 현재 (환경별 동적 처리)
if (url.includes("mock-gcp-bucket")) {
  const baseUrl = getImageBaseUrl();  // ✅ 환경별 동적 선택
  return url.replace("https://mock-gcp-bucket", baseUrl);
}

2. 이미지 업로드 처리 순서 개선
// 이전 (잘못된 순서)
let imageUrl = response.data;
if (imageUrl && !imageUrl.startsWith("http")) {
  // 상대 경로 처리
}
if (imageUrl && imageUrl.includes("mock-gcp-bucket")) {
  // mock URL 변환 (나중에 처리)
}

// 현재 (올바른 순서)
let imageUrl = response.data;
if (imageUrl && imageUrl.includes("mock-gcp-bucket")) {
  // mock URL 변환 (먼저 처리)
  imageUrl = convertMockUrlToCdnUrl(imageUrl);
}
if (imageUrl && !imageUrl.startsWith("http")) {
  // 상대 경로 처리 (나중에 처리)
}

### 기술적 접근
getImageBaseUrl() 함수를 활용한 환경별 URL 동적 선택
이미지 업로드 응답 처리 순서 최적화
기존 convertMockUrlToCdnUrl 함수의 재사용성 향상

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->

개발 환경 테스트: localhost에서 이미지 업로드 시 https://dev.cdn-feedshop.store/... URL 생성 확인
운영 환경 테스트: 프로덕션 도메인에서 이미지 업로드 시 https://cdn-feedshop.store/... URL 생성 확인
프로필 이미지 표시 테스트: 업로드된 이미지가 정상적으로 프로필 페이지에 표시되는지 확인
DB 저장 확인: 실제 CDN URL이 DB에 올바르게 저장되는지 확인

### 확인 사항
[x] 개발 환경에서 올바른 CDN URL 생성 확인
[x] 운영 환경에서 올바른 CDN URL 생성 확인
[x] 프로필 이미지 정상 표시 확인
[x] 기존 기능 영향 없음 확인
[x] 에러 케이스 처리 확인

---

## 📎 관련 이슈 / 문서
- 관련 이슈: 없음
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-223](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

환경별 URL 매핑:
개발 환경: https://dev.cdn-feedshop.store
운영 환경: https://cdn-feedshop.store
변환 예시:
입력: https://mock-gcp-bucket/mock-path/image.jpg
개발 출력: https://dev.cdn-feedshop.store/mock-path/image.jpg
운영 출력: https://cdn-feedshop.store/mock-path/image.jpg
백엔드 연동: 백엔드에서 여전히 mock URL을 반환하지만, 프론트엔드에서 올바른 CDN URL로 변환하여 DB에 저장
하위 호환성: 기존 mock URL 처리 로직은 그대로 유지하면서 환경별 처리만 개선

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
