### PR TITLE
MYCE-185 feat: 구글 소셜 로그인 기능 구현

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -11,8 +11,10 @@
     <link
       rel="stylesheet"
       href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.0.0-beta3/css/all.min.css"
+      integrity="sha512-Fo3rlrZj/k7ujTnHg4Cgr2D7kSs0x4q9dFfto+t89UfevB33yVlW3a/wBwQ/1C1L"
+      crossorigin="anonymous"
+      referrerpolicy="no-referrer"
     />
-    <!-- 다음 우편번호 서비스 -->
     <script src="//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js"></script>
     <title>쇼핑몰</title>
   </head>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -66,6 +66,7 @@ const EventEditPage = lazy(() => import("./pages/event/EventEditPage"));
 const EventResultPage = lazy(() => import("./pages/event/EventResultPage"));
 const BecomeSellerPage = lazy(() => import("./pages/seller/BecomeSellerPage"));
 const SellerMyPage = lazy(() => import("./pages/seller/SellerMyPage"));
+const SocialCallbackPage = lazy(() => import("./pages/auth/SocialCallbackPage"));
 
 const RECAPTCHA_SITE_KEY = process.env.REACT_APP_RECAPTCHA_SITE_KEY || "";
 
@@ -311,6 +312,7 @@ const App: FC = () => {
               <Route path="/find-account" element={<FindAccountPage />} />
               <Route path="/find-password" element={<FindPasswordPage />} />
               <Route path="/reset-password" element={<ResetPasswordPage />} />
+              <Route path="/auth/callback" element={<SocialCallbackPage />} />
             </Routes>
           </Suspense>
         </AuthProvider>

--- a/src/api/productService.ts
+++ b/src/api/productService.ts
@@ -5,6 +5,7 @@ import {
   CreateProductRequest,
   ProductDetail,
   ProductListResponse,
+  ProductListItem,
   UpdateProductRequest,
 } from "types/products";
 
@@ -35,15 +36,51 @@ export class ProductService {
     size?: number;
     storeId?: number;
     sort?: string; // 정렬 방식
+    colors?: string[]; // 색상 필터
+    sizes?: string[]; // 사이즈 필터
+    genders?: string[]; // 성별 필터
+    inStockOnly?: boolean; // 재고 있는 상품만
+    discountedOnly?: boolean; // 할인 상품만
   }): Promise<ProductListResponse> {
     try {
+      // 배열 파라미터를 쉼표로 구분된 문자열로 변환 (API 명세서에 따라)
+      const processedParams = {
+        ...params,
+        colors:
+          params.colors && params.colors.length > 0
+            ? params.colors.join(",")
+            : undefined,
+        sizes:
+          params.sizes && params.sizes.length > 0
+            ? params.sizes.join(",")
+            : undefined,
+        genders:
+          params.genders && params.genders.length > 0
+            ? params.genders.join(",")
+            : undefined,
+      };
+
+      // undefined 값 제거
+      const cleanParams = Object.fromEntries(
+        Object.entries(processedParams).filter(
+          ([_, value]) => value !== undefined
+        )
+      );
+
+      console.log("API 요청 파라미터:", cleanParams); // 디버깅용
+
       // API 명세서에 따라 /api/products 엔드포인트 사용
       const response = await axiosInstance.get<
         ApiResponse<ProductListResponse>
-      >("/api/products", { params });
+      >("/api/products", {
+        params: cleanParams,
+      });
+
+      console.log("API 응답:", response.data); // 디버깅용
       return response.data.data;
     } catch (error: any) {
-      console.error("상품 조회 실패:", error);
+      console.error("필터링된 상품 조회 실패:", error);
+      console.error("에러 상세:", error.response?.data);
       throw error;
     }
   }
@@ -77,9 +114,67 @@ export class ProductService {
     productData: CreateProductRequest
   ): Promise<{ productId: number }> {
     try {
+      const formData = new FormData();
+
+      // 상품 정보 (images 필드 제외)
+      const { images, ...productInfo } = productData;
+
+      // 백엔드 DTO에 맞는 images 배열 생성
+      const imageRequests = images
+        .filter(img => img.file || img.url) // 유효한 이미지만 필터링
+        .map(img => ({
+          url: img.url,
+          type: img.isMain || img.type === "MAIN" ? "MAIN" : "DETAIL"
+        }));
+
+      const productJson = {
+        ...productInfo,
+        images: imageRequests, // 백엔드가 기대하는 형태로 전송
+        options: productInfo.options.map(option => ({
+          gender: option.gender,
+          size: option.size.replace('SIZE_', ''), // SIZE_250 -> 250
+          color: option.color,
+          stock: option.stock
+        }))
+      };
+
+      formData.append(
+        "product",
+        new Blob([JSON.stringify(productJson)], {
+          type: "application/json",
+        })
+      );
+
+      // 이미지 파일들 분리
+      const mainImageFiles: File[] = [];
+      const detailImageFiles: File[] = [];
+
+      images.forEach(image => {
+        if (image.file) {
+          if (image.isMain || image.type === "MAIN") {
+            mainImageFiles.push(image.file);
+          } else {
+            detailImageFiles.push(image.file);
+          }
+        }
+      });
+
+      // 이미지 파일 추가 (파일이 있을 때만)
+      mainImageFiles.forEach(file => {
+        formData.append("mainImages", file);
+      });
+
+      detailImageFiles.forEach(file => {
+        formData.append("detailImages", file);
+      });
+
       const response = await axiosInstance.post<
         ApiResponse<{ productId: number }>
-      >("/api/seller/products", productData);
+      >("/api/seller/products", formData, {
+        headers: {
+          "Content-Type": "multipart/form-data",
+        },
+      });
       return response.data.data;
     } catch (error: any) {
       throw error;
@@ -92,9 +187,60 @@ export class ProductService {
     productData: UpdateProductRequest
   ): Promise<void> {
     try {
+      const formData = new FormData();
+
+      // 상품 정보 (images 필드 제외)
+      const { images, options, ...productInfo } = productData;
+      const productJson = {
+        ...productInfo,
+        options: options?.map(option => ({
+          gender: option.gender,
+          size: option.size?.replace('SIZE_', ''), // SIZE_250 -> 250
+          color: option.color,
+          stock: option.stock
+        }))
+      };
+
+      formData.append(
+        "product",
+        new Blob([JSON.stringify(productJson)], {
+          type: "application/json",
+        })
+      );
+
+      // 이미지 파일들 분리 (수정 시에도 새 이미지가 있을 경우)
+      if (images && images.length > 0) {
+        const mainImageFiles: File[] = [];
+        const detailImageFiles: File[] = [];
+
+        images.forEach(image => {
+          if (image.file) {
+            if (image.isMain || image.type === "MAIN") {
+              mainImageFiles.push(image.file);
+            } else {
+              detailImageFiles.push(image.file);
+            }
+          }
+        });
+
+        // 이미지 파일 추가
+        mainImageFiles.forEach(file => {
+          formData.append("mainImages", file);
+        });
+
+        detailImageFiles.forEach(file => {
+          formData.append("detailImages", file);
+        });
+      }
+
       await axiosInstance.put<ApiResponse<null>>(
         `/api/seller/products/${productId}`,
-        productData
+        formData,
+        {
+          headers: {
+            "Content-Type": "multipart/form-data",
+          },
+        }
       );
     } catch (error: any) {
       console.error("상품 수정 실패:", error);
@@ -118,10 +264,26 @@ export class ProductService {
   static async getSellerProducts(
     page: number = 0,
     size: number = 20
-  ): Promise<ProductListResponse> {
+  ): Promise<{
+    content: ProductListItem[];
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    number: number;
+    first: boolean;
+    last: boolean;
+  }> {
     try {
       const response = await axiosInstance.get<
-        ApiResponse<ProductListResponse>
+        ApiResponse<{
+          content: ProductListItem[];
+          totalElements: number;
+          totalPages: number;
+          size: number;
+          number: number;
+          first: boolean;
+          last: boolean;
+        }>
       >("/api/seller/products", { params: { page, size } });
       return response.data.data;
     } catch (error: any) {

--- a/src/api/socialAuthService.ts
+++ b/src/api/socialAuthService.ts
@@ -1,0 +1,107 @@
+import axiosInstance from "./axios";
+
+// 소셜 로그인 관련 API 서비스
+
+export interface SocialProvider {
+  provider: string;
+  connected: boolean;
+  email?: string;
+  connectedAt?: string;
+}
+
+export interface SocialLoginResponse {
+  providers: SocialProvider[];
+  totalConnected: number;
+}
+
+export class SocialAuthService {
+  /**
+   * 현재 사용자의 소셜 로그인 연동 정보 조회
+   */
+  static async getUserSocialProviders(): Promise<SocialLoginResponse> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: SocialLoginResponse;
+    }>("/api/social/providers");
+    
+    return response.data.data;
+  }
+
+  /**
+   * 특정 소셜 제공자 연동 해제
+   */
+  static async unlinkProvider(provider: string): Promise<string> {
+    const response = await axiosInstance.delete<{
+      success: boolean;
+      data: string;
+    }>(`/api/social/providers/${provider}`);
+    
+    return response.data.data;
+  }
+
+  /**
+   * 소셜 로그인 지원 제공자 목록 조회
+   */
+  static async getSupportedProviders(): Promise<string[]> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: string[];
+    }>("/api/social/supported-providers");
+    
+    return response.data.data;
+  }
+
+  /**
+   * 소셜 로그인 URL 생성 (개발/테스트용)
+   */
+  static async getSocialLoginUrls(): Promise<{ [key: string]: string }> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: { [key: string]: string };
+    }>("/api/auth/test/social-login-urls");
+    
+    return response.data.data;
+  }
+
+  /**
+   * 현재 인증 상태 확인 (개발/테스트용)
+   */
+  static async getAuthStatus(): Promise<{
+    authenticated: boolean;
+    username?: string;
+    message: string;
+  }> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: {
+        authenticated: boolean;
+        username?: string;
+        message: string;
+      };
+    }>("/api/auth/test/auth-status");
+    
+    return response.data.data;
+  }
+
+  /**
+   * OAuth2 콜백 정보 조회 (개발/테스트용)
+   */
+  static async getCallbackInfo(): Promise<{
+    frontendCallbackUrl: string;
+    description: string;
+    parameters: string;
+  }> {
+    const response = await axiosInstance.get<{
+      success: boolean;
+      data: {
+        frontendCallbackUrl: string;
+        description: string;
+        parameters: string;
+      };
+    }>("/api/auth/test/callback-info");
+    
+    return response.data.data;
+  }
+}
+
+export default SocialAuthService;

--- a/src/api/storeService.ts
+++ b/src/api/storeService.ts
@@ -1,0 +1,50 @@
+import { Store, SellerStore } from "types/products";
+import axiosInstance from "./axios";
+import { ApiResponse } from "types/api";
+
+export class StoreService {
+  static async getStores(): Promise<Store[]> {
+    try {
+      const response = await axiosInstance.get<ApiResponse<Store[]>>(
+        "/api/stores"
+      );
+
+      if (
+        response.data &&
+        response.data.success &&
+        Array.isArray(response.data.data)
+      ) {
+        return response.data.data;
+      } else {
+        return [];
+      }
+    } catch (error: any) {
+      console.error("스토어 목록 조회 실패:", error);
+      throw new Error(
+        error.response?.data?.message ||
+          "스토어 목록을 불러오는데 실패했습니다."
+      );
+    }
+  }
+
+  static async getSellerStore(): Promise<SellerStore> {
+    try {
+      const response = await axiosInstance.get<ApiResponse<SellerStore>>(
+        "/api/seller/stores"
+      );
+
+      if (response.data && response.data.success && response.data.data) {
+        return response.data.data;
+      } else {
+        throw new Error("가게 정보를 찾을 수 없습니다.");
+      }
+    } catch (error: any) {
+      console.error("판매자 가게 정보 조회 실패:", error);
+      throw new Error(
+        error.response?.data?.message || "가게 정보를 불러오는데 실패했습니다."
+      );
+    }
+  }
+}
+
+export default StoreService;

--- a/src/api/wishlistService.ts
+++ b/src/api/wishlistService.ts
@@ -1,0 +1,78 @@
+import { ApiResponse } from "types/feed";
+import axiosInstance from "./axios";
+
+// 찜 목록 응답 타입 정의
+export interface WishlistItem {
+  wishlistId: number;
+  productId: number;
+  productName: string;
+  productImageUrl: string;
+  productPrice: number;
+  discountType: string;
+  discountValue: number;
+  createdAt: string;
+}
+
+export interface WishlistResponse {
+  wishlists: WishlistItem[];
+  totalPages: number;
+  totalElements: number;
+  hasNext: boolean;
+}
+
+export interface AddWishlistRequest {
+  productId: number;
+}
+
+export interface AddWishlistResponse {
+  wishlistId: number;
+  productId: number;
+  createdAt: string;
+}
+
+export class WishlistService {
+  // 찜 목록 추가
+  static async addToWishlist(productId: number): Promise<AddWishlistResponse> {
+    try {
+      const response = await axiosInstance.post<ApiResponse<AddWishlistResponse>>(
+        "/api/users/wishlist",
+        { productId }
+      );
+      return response.data.data;
+    } catch (error: any) {
+      console.error("찜 목록 추가 실패:", error);
+      throw error;
+    }
+  }
+
+  // 찜 목록 조회
+  static async getWishlist(
+    page: number = 0,
+    size: number = 9
+  ): Promise<WishlistResponse> {
+    try {
+      const response = await axiosInstance.get<ApiResponse<WishlistResponse>>(
+        "/api/users/wishlist",
+        { params: { page, size } }
+      );
+      return response.data.data;
+    } catch (error: any) {
+      console.error("찜 목록 조회 실패:", error);
+      throw error;
+    }
+  }
+
+  // 찜 목록에서 제거
+  static async removeFromWishlist(productId: number): Promise<void> {
+    try {
+      await axiosInstance.delete<ApiResponse<null>>(
+        `/api/users/wishlist/${productId}`
+      );
+    } catch (error: any) {
+      console.error("찜 목록 제거 실패:", error);
+      throw error;
+    }
+  }
+}
+
+export default WishlistService;

--- a/src/components/order/ProductPreviewSection.tsx
+++ b/src/components/order/ProductPreviewSection.tsx
@@ -93,8 +93,14 @@ export const ProductPreviewSection: React.FC<ProductPreviewSectionProps> = ({
                 {/* 상품명 */}
                 <ProductName>{item.productName}</ProductName>
 
-                {/* 상품 세부 옵션 정보 (사이즈, 수량) */}
+                {/* 상품 세부 옵션 정보 (성별, 색상, 사이즈, 수량) */}
                 <ProductDetails>
+                  {item.gender && (
+                    <>
+                      {item.gender === "MEN" ? "남성" : item.gender === "WOMEN" ? "여성" : "공용"} | 
+                    </>
+                  )}
+                  {item.color && <>{item.color} | </>}
                   사이즈: {item.size} | 수량: {item.quantity}개
                 </ProductDetails>
               </ProductInfo>

--- a/src/components/products/FilterButtons.styles.ts
+++ b/src/components/products/FilterButtons.styles.ts
@@ -1,0 +1,188 @@
+import styled from "styled-components";
+
+export const FilterContainer = styled.div`
+  background: white;
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 28px;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.05);
+  border: 1px solid #e2e8f0;
+  transition: box-shadow 0.2s ease;
+
+  &:hover {
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.08);
+  }
+`;
+
+export const FilterRow = styled.div`
+  display: flex;
+  gap: 24px;
+  margin-bottom: 24px;
+  flex-wrap: wrap;
+  align-items: stretch;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &:first-child {
+    margin-bottom: 28px;
+    padding-bottom: 20px;
+    border-bottom: 1px solid #f1f5f9;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 20px;
+    align-items: stretch;
+    
+    &:first-child {
+      margin-bottom: 24px;
+      padding-bottom: 16px;
+    }
+  }
+`;
+
+export const FilterGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-width: 160px;
+  flex: 1;
+
+  @media (max-width: 768px) {
+    min-width: auto;
+    flex: none;
+  }
+`;
+
+export const FilterLabel = styled.label`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #374151;
+  margin-bottom: 6px;
+  text-transform: capitalize;
+  letter-spacing: 0.025em;
+`;
+
+export const FilterDropdown = styled.select<{ $hasValue?: boolean }>`
+  padding: 10px 12px;
+  border: 1px solid ${props => props.$hasValue ? '#3b82f6' : '#d1d5db'};
+  border-radius: 8px;
+  background: ${props => props.$hasValue ? '#eff6ff' : 'white'};
+  font-size: 0.875rem;
+  color: #374151;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  min-width: 140px;
+  height: 40px;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+
+  &:hover:not(:disabled) {
+    border-color: #9ca3af;
+  }
+
+  &:disabled {
+    background: #f9fafb;
+    cursor: not-allowed;
+    opacity: 0.6;
+  }
+
+  @media (max-width: 768px) {
+    min-width: auto;
+    width: 100%;
+  }
+`;
+
+export const FilterInput = styled.input`
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 8px;
+  background: white;
+  font-size: 0.875rem;
+  color: #374151;
+  transition: all 0.2s ease;
+  width: 120px;
+  height: 40px;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+
+  &:hover {
+    border-color: #9ca3af;
+  }
+
+  &::placeholder {
+    color: #9ca3af;
+    font-size: 0.8rem;
+  }
+
+  @media (max-width: 768px) {
+    width: 100%;
+  }
+`;
+
+export const PriceRangeContainer = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 8px;
+
+  span {
+    color: #6b7280;
+    font-size: 0.875rem;
+    font-weight: 500;
+  }
+
+  @media (max-width: 768px) {
+    flex-direction: column;
+    gap: 12px;
+
+    span {
+      display: none;
+    }
+  }
+`;
+
+export const ClearButton = styled.button`
+  padding: 8px 16px;
+  background: #ef4444;
+  color: white;
+  border: none;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  height: 36px;
+  align-self: flex-end;
+  white-space: nowrap;
+
+  &:hover {
+    background: #dc2626;
+    transform: translateY(-1px);
+  }
+
+  &:active {
+    transform: translateY(0);
+  }
+`;
+
+export const ClearButtonContainer = styled.div`
+  display: flex;
+  align-items: flex-end;
+  padding-left: 20px;
+  
+  @media (max-width: 768px) {
+    padding-left: 0;
+    margin-top: 16px;
+    justify-content: center;
+  }
+`;

--- a/src/components/products/FilterButtons.tsx
+++ b/src/components/products/FilterButtons.tsx
@@ -1,74 +1,408 @@
 /**
- * 상품 정렬 버튼 컴포넌트
+ * 상품 필터 및 정렬 버튼 컴포넌트
  *
  * 기능:
- * - 상품 목록 페이지에서 정렬 옵션 버튼 제공
- * - 최신순(기본), 인기순 2가지 정렬 옵션 표시
- * - 현재 선택된 정렬의 시각적 상태 관리
- * - 정렬 변경 시 콜백 함수를 통한 상태 업데이트
+ * - 상품 목록 페이지에서 다양한 필터링 및 정렬 옵션 제공
+ * - 정렬: 최신순, 인기순, 가격순, 할인순
+ * - 필터: 재고 있는 상품만, 할인 상품만, 성별, 가격 범위, 스토어
+ * - 현재 선택된 필터의 시각적 상태 관리
+ * - 필터 변경 시 콜백 함수를 통한 상태 업데이트
  *
  * 제공 기능:
- * - 활성 정렬에 대한 시각적 피드백
- * - 한국어 현지화된 정렬 라벨
- * - 반응형 버튼 레이아웃
- * - 클릭 핸들러를 통한 정렬 전환
+ * - 활성 필터에 대한 시각적 피드백
+ * - 깔끔하고 직관적인 레이아웃
+ * - 반응형 버튼 배치
+ * - 드롭다운 및 범위 선택 UI
  *
  * 사용되는 곳:
  * - Lists.tsx (상품 목록 페이지)
- * - 상품 카탈로그 뷰
- *
- * UX 고려사항:
- * - 활성 상태가 사용자에게 명확한 시각적 피드백 제공
- * - 버튼 라벨이 간결하고 이해하기 쉬움
- * - 전체 디자인 시스템과 일관된 스타일링
- * - 접근성을 고려한 버튼 인터랙션
  */
 
-// React 라이브러리
-import React from "react";
-// 스타일 컴포넌트들
+import React, { useState, useEffect, useCallback } from "react";
+import { CategoryService } from "../../api/categoryService";
+import { StoreService } from "../../api/storeService";
+import { Category, Store } from "types/products";
 import {
-  FilterSection, // 필터 섹션 컨테이너
-  FilterButton, // 개별 필터 버튼
+  FilterSection,
+  FilterButton,
 } from "../../pages/products/Lists.styles";
+import {
+  FilterContainer,
+  FilterRow,
+  FilterGroup,
+  FilterLabel,
+  FilterDropdown,
+  FilterInput,
+  PriceRangeContainer,
+  ClearButton,
+  ClearButtonContainer,
+} from "./FilterButtons.styles";
 
-/**
- * FilterButtons 컴포넌트의 Props 인터페이스
- */
+// 디바운싱을 위한 커스텀 훅
+const useDebounce = (value: any, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState(value);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value);
+    }, delay);
+
+    return () => {
+      clearTimeout(handler);
+    };
+  }, [value, delay]);
+
+  return debouncedValue;
+};
+
 interface FilterButtonsProps {
-  activeSort: string; // 현재 선택된 정렬 값 ("latest", "popular")
-  onSortChange: (sort: string) => void; // 정렬 변경 시 호출되는 콜백 함수
+  activeSort: string;
+  onSortChange: (sort: string) => void;
+  filters: ProductFilters;
+  onFiltersChange: (filters: ProductFilters) => void;
 }
 
-/**
- * 상품 정렬 버튼 컴포넌트
- *
- * 사용자가 상품 목록을 다양한 방식으로 정렬할 수 있도록
- * 가로 배열의 정렬 버튼들을 렌더링합니다.
- * 각 버튼은 활성 상태에서 시각적 피드백을 제공하고,
- * 부모 컴포넌트의 정렬 변경 핸들러를 호출합니다.
- */
+export interface ProductFilters {
+  sort: string;
+  categoryId?: number;
+  inStockOnly?: boolean;
+  discountedOnly?: boolean;
+  genders?: string[];
+  colors?: string[];
+  sizes?: string[];
+  minPrice?: number;
+  maxPrice?: number;
+  storeId?: number;
+}
+
+// 색상 옵션 (API 명세서 기준: ProductListFiltering.md 참조)
+const COLOR_OPTIONS = [
+  { value: "WHITE", label: "화이트" },
+  { value: "SILVER", label: "실버" },
+  { value: "LIGHT_GRAY", label: "연한 회색" },
+  { value: "GRAY", label: "회색" },
+  { value: "DARK_GRAY", label: "진한 회색" },
+  { value: "BLACK", label: "블랙" },
+  { value: "RED", label: "레드" },
+  { value: "DEEP_RED", label: "진한 빨간색" },
+  { value: "BURGUNDY", label: "버건디" },
+  { value: "PALE_PINK", label: "연한 핑크" },
+  { value: "LIGHT_PINK", label: "밝은 핑크" },
+  { value: "PINK", label: "핑크" },
+  { value: "DARK_PINK", label: "진한 핑크" },
+  { value: "PEACH", label: "피치" },
+  { value: "LIGHT_ORANGE", label: "밝은 오렌지" },
+  { value: "ORANGE", label: "오렌지" },
+  { value: "DARK_ORANGE", label: "진한 오렌지" },
+  { value: "IVORY", label: "아이보리" },
+  { value: "LIGHT_YELLOW", label: "밝은 노란색" },
+  { value: "YELLOW", label: "노란색" },
+  { value: "MUSTARD", label: "머스타드" },
+  { value: "GOLD", label: "골드" },
+  { value: "LIME", label: "라임" },
+  { value: "LIGHT_GREEN", label: "밝은 초록" },
+  { value: "GREEN", label: "초록색" },
+  { value: "OLIVE_GREEN", label: "올리브 그린" },
+  { value: "KHAKI", label: "카키" },
+  { value: "DARK_GREEN", label: "진한 초록" },
+  { value: "MINT", label: "민트" },
+  { value: "SKY_BLUE", label: "하늘색" },
+  { value: "BLUE", label: "블루" },
+  { value: "DARK_BLUE", label: "진한 블루" },
+  { value: "NAVY", label: "네이비" },
+  { value: "DARK_NAVY", label: "진한 네이비" },
+  { value: "LAVENDER", label: "라벤더" },
+  { value: "PURPLE", label: "퍼플" },
+  { value: "LIGHT_BROWN", label: "밝은 브라운" },
+  { value: "BROWN", label: "브라운" },
+  { value: "DARK_BROWN", label: "진한 브라운" },
+  { value: "SAND", label: "샌드" },
+  { value: "BEIGE", label: "베이지" },
+  { value: "DARK_BEIGE", label: "진한 베이지" },
+  { value: "KHAKI_BEIGE", label: "카키 베이지" },
+  { value: "OTHER_COLORS", label: "기타 색상" },
+];
+
+// 사이즈 옵션 (API 명세에 따른)
+const SIZE_OPTIONS = [
+  "230", "235", "240", "245", "250", "255", "260", "265", "270", "275", "280", "285", "290", "295", "300"
+];
+
+// 성별 옵션
+const GENDER_OPTIONS = [
+  { value: "MEN", label: "남성" },
+  { value: "WOMEN", label: "여성" },
+  { value: "UNISEX", label: "공용" },
+];
+
 export const FilterButtons: React.FC<FilterButtonsProps> = ({
   activeSort,
   onSortChange,
+  filters,
+  onFiltersChange,
 }) => {
-  return (
-    <FilterSection>
-      {/* "최신순" 정렬 버튼 - 상품 등록일 내림차순 정렬 (기본값) */}
-      <FilterButton
-        $active={activeSort === "latest"} // "latest" 정렬 선택 시 시각적 활성 상태
-        onClick={() => onSortChange("latest")} // 최신순 정렬을 위한 정렬 변경 트리거
-      >
-        최신순
-      </FilterButton>
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [stores, setStores] = useState<Store[]>([]);
+  const [loading, setLoading] = useState(false);
+  
+  // 가격 입력 로컬 상태 (디바운싱을 위해)
+  const [localMinPrice, setLocalMinPrice] = useState(filters.minPrice?.toString() || "");
+  const [localMaxPrice, setLocalMaxPrice] = useState(filters.maxPrice?.toString() || "");
+  
+  // 디바운싱된 가격 값
+  const debouncedMinPrice = useDebounce(localMinPrice, 500);
+  const debouncedMaxPrice = useDebounce(localMaxPrice, 500);
 
-      {/* "인기순" 정렬 버튼 - 찜 수(wishNumber) 내림차순 정렬 */}
-      <FilterButton
-        $active={activeSort === "popular"} // "popular" 정렬 선택 시 시각적 활성 상태
-        onClick={() => onSortChange("popular")} // 인기순 정렬을 위한 정렬 변경 트리거
-      >
-        인기순
-      </FilterButton>
-    </FilterSection>
+  useEffect(() => {
+    const loadFilterData = async () => {
+      setLoading(true);
+      try {
+        const [categoriesData, storesData] = await Promise.all([
+          CategoryService.getCategories(),
+          StoreService.getStores(),
+        ]);
+        setCategories(categoriesData);
+        setStores(storesData);
+      } catch (error) {
+        console.error("필터 데이터 로딩 실패:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    loadFilterData();
+  }, []);
+
+  // 디바운싱된 가격이 변경될 때만 필터 업데이트
+  useEffect(() => {
+    const minPrice = debouncedMinPrice ? parseInt(debouncedMinPrice) : undefined;
+    const maxPrice = debouncedMaxPrice ? parseInt(debouncedMaxPrice) : undefined;
+    
+    if (minPrice !== filters.minPrice || maxPrice !== filters.maxPrice) {
+      onFiltersChange({
+        ...filters,
+        minPrice,
+        maxPrice,
+      });
+    }
+  }, [debouncedMinPrice, debouncedMaxPrice]);
+
+  // 필터가 외부에서 변경될 때 로컬 상태 동기화
+  useEffect(() => {
+    setLocalMinPrice(filters.minPrice?.toString() || "");
+    setLocalMaxPrice(filters.maxPrice?.toString() || "");
+  }, [filters.minPrice, filters.maxPrice]);
+
+  const handleFilterChange = useCallback((key: keyof ProductFilters, value: any) => {
+    onFiltersChange({
+      ...filters,
+      [key]: value,
+    });
+  }, [filters, onFiltersChange]);
+
+  const clearAllFilters = () => {
+    setLocalMinPrice("");
+    setLocalMaxPrice("");
+    const resetFilters: ProductFilters = {
+      sort: 'latest',
+    };
+    // 즉시 필터 상태를 리셋하고 API 호출
+    onFiltersChange(resetFilters);
+    onSortChange('latest');
+  };
+
+  const hasActiveFilters = Object.keys(filters).some(key => 
+    key !== 'sort' && filters[key as keyof ProductFilters] !== undefined
+  );
+
+  return (
+    <FilterContainer>
+      {/* 정렬 버튼들 */}
+      <FilterRow>
+        <FilterGroup>
+          <FilterLabel>정렬</FilterLabel>
+          <FilterSection>
+            <FilterButton
+              $active={activeSort === "latest"}
+              onClick={() => onSortChange("latest")}
+            >
+              최신순
+            </FilterButton>
+            <FilterButton
+              $active={activeSort === "popular"}
+              onClick={() => onSortChange("popular")}
+            >
+              인기순
+            </FilterButton>
+            <FilterButton
+              $active={activeSort === "price_asc"}
+              onClick={() => onSortChange("price_asc")}
+            >
+              가격 낮은순
+            </FilterButton>
+            <FilterButton
+              $active={activeSort === "price_desc"}
+              onClick={() => onSortChange("price_desc")}
+            >
+              가격 높은순
+            </FilterButton>
+            <FilterButton
+              $active={activeSort === "discount_desc"}
+              onClick={() => onSortChange("discount_desc")}
+            >
+              할인율순
+            </FilterButton>
+          </FilterSection>
+        </FilterGroup>
+      </FilterRow>
+
+      {/* 기본 필터 옵션들 */}
+      <FilterRow>
+        <FilterGroup>
+          <FilterLabel>카테고리</FilterLabel>
+          <FilterDropdown
+            value={filters.categoryId?.toString() || ""}
+            $hasValue={!!filters.categoryId}
+            onChange={(e) => {
+              const value = e.target.value;
+              handleFilterChange('categoryId', value ? parseInt(value) : undefined);
+            }}
+            disabled={loading}
+          >
+            <option value="">전체 카테고리</option>
+            {categories.map(category => (
+              <option key={category.categoryId} value={category.categoryId}>
+                {category.name}
+              </option>
+            ))}
+          </FilterDropdown>
+        </FilterGroup>
+
+        <FilterGroup>
+          <FilterLabel>스토어</FilterLabel>
+          <FilterDropdown
+            value={filters.storeId?.toString() || ""}
+            $hasValue={!!filters.storeId}
+            onChange={(e) => {
+              const value = e.target.value;
+              handleFilterChange('storeId', value ? parseInt(value) : undefined);
+            }}
+            disabled={loading}
+          >
+            <option value="">전체 스토어</option>
+            {stores.map(store => (
+              <option key={store.storeId} value={store.storeId}>
+                {store.storeName}
+              </option>
+            ))}
+          </FilterDropdown>
+        </FilterGroup>
+
+        <FilterGroup>
+          <FilterLabel>성별</FilterLabel>
+          <FilterDropdown
+            value={filters.genders?.[0] || ""}
+            $hasValue={!!(filters.genders && filters.genders.length > 0)}
+            onChange={(e) => {
+              const value = e.target.value;
+              handleFilterChange('genders', value ? [value] : undefined);
+            }}
+          >
+            <option value="">전체</option>
+            {GENDER_OPTIONS.map(gender => (
+              <option key={gender.value} value={gender.value}>
+                {gender.label}
+              </option>
+            ))}
+          </FilterDropdown>
+        </FilterGroup>
+
+        <FilterGroup>
+          <FilterLabel>상품 상태</FilterLabel>
+          <FilterSection>
+            <FilterButton
+              $active={filters.inStockOnly === true}
+              onClick={() => handleFilterChange('inStockOnly', filters.inStockOnly ? undefined : true)}
+            >
+              재고 있음
+            </FilterButton>
+            <FilterButton
+              $active={filters.discountedOnly === true}
+              onClick={() => handleFilterChange('discountedOnly', filters.discountedOnly ? undefined : true)}
+            >
+              할인 상품
+            </FilterButton>
+          </FilterSection>
+        </FilterGroup>
+      </FilterRow>
+
+      {/* 상세 필터 및 초기화 */}
+      <FilterRow>
+        <FilterGroup>
+          <FilterLabel>가격 범위</FilterLabel>
+          <PriceRangeContainer>
+            <FilterInput
+              type="number"
+              placeholder="최소 가격"
+              value={localMinPrice}
+              onChange={(e) => setLocalMinPrice(e.target.value)}
+            />
+            <span>~</span>
+            <FilterInput
+              type="number"
+              placeholder="최대 가격"
+              value={localMaxPrice}
+              onChange={(e) => setLocalMaxPrice(e.target.value)}
+            />
+          </PriceRangeContainer>
+        </FilterGroup>
+
+        <FilterGroup>
+          <FilterLabel>색상</FilterLabel>
+          <FilterDropdown
+            value={filters.colors?.[0] || ""}
+            $hasValue={!!(filters.colors && filters.colors.length > 0)}
+            onChange={(e) => {
+              const value = e.target.value;
+              handleFilterChange('colors', value ? [value] : undefined);
+            }}
+          >
+            <option value="">전체 색상</option>
+            {COLOR_OPTIONS.map(color => (
+              <option key={color.value} value={color.value}>
+                {color.label}
+              </option>
+            ))}
+          </FilterDropdown>
+        </FilterGroup>
+
+        <FilterGroup>
+          <FilterLabel>사이즈</FilterLabel>
+          <FilterDropdown
+            value={filters.sizes?.[0] || ""}
+            $hasValue={!!(filters.sizes && filters.sizes.length > 0)}
+            onChange={(e) => {
+              const value = e.target.value;
+              handleFilterChange('sizes', value ? [value] : undefined);
+            }}
+          >
+            <option value="">전체 사이즈</option>
+            {SIZE_OPTIONS.map(size => (
+              <option key={size} value={size}>
+                {size}
+              </option>
+            ))}
+          </FilterDropdown>
+        </FilterGroup>
+
+        {hasActiveFilters && (
+          <ClearButtonContainer>
+            <ClearButton onClick={clearAllFilters}>
+              필터 초기화
+            </ClearButton>
+          </ClearButtonContainer>
+        )}
+      </FilterRow>
+    </FilterContainer>
   );
 };

--- a/src/components/products/ModernOptionSelector.tsx
+++ b/src/components/products/ModernOptionSelector.tsx
@@ -1,0 +1,434 @@
+/**
+ * ModernOptionSelector 컴포넌트
+ *
+ * 성별, 색상, 사이즈를 모던한 UI로 선택할 수 있는 컴포넌트입니다.
+ * - 성별: Dropdown 선택
+ * - 색상: 색상별 컬러 토글 버튼
+ * - 사이즈: Compact한 토글 버튼
+ */
+
+import React, { useState } from "react";
+import styled from "styled-components";
+import { ProductDetail } from "types/products";
+import { SelectedOptions } from "../../hooks/products/useProductOptions";
+
+// 스타일 컴포넌트들
+const OptionContainer = styled.div`
+  margin: 24px 0;
+  background: #f8fafc;
+  border-radius: 12px;
+  padding: 24px;
+  border: 1px solid #e5e7eb;
+`;
+
+const OptionsGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: 20px;
+  margin-bottom: 20px;
+  
+  @media (max-width: 640px) {
+    grid-template-columns: 1fr;
+    gap: 16px;
+  }
+`;
+
+const OptionGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+`;
+
+const OptionLabel = styled.label`
+  font-weight: 600;
+  font-size: 14px;
+  color: #374151;
+  margin-bottom: 8px;
+  display: block;
+`;
+
+const SizesSection = styled.div`
+  grid-column: 1 / -1;
+  
+  @media (max-width: 640px) {
+    grid-column: 1;
+  }
+`;
+
+// Dropdown 스타일
+const DropdownContainer = styled.div`
+  position: relative;
+`;
+
+const DropdownButton = styled.button`
+  width: 100%;
+  padding: 12px 16px;
+  background: white;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 500;
+  text-align: left;
+  cursor: pointer;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  transition: all 0.2s ease;
+  min-height: 44px;
+
+  &:hover {
+    border-color: #6366f1;
+    background: #f9fafb;
+  }
+
+  &:focus {
+    outline: none;
+    border-color: #6366f1;
+    box-shadow: 0 0 0 3px rgba(99, 102, 241, 0.1);
+  }
+`;
+
+const DropdownArrow = styled.span<{ $isOpen: boolean }>`
+  transform: rotate(${props => props.$isOpen ? '180deg' : '0deg'});
+  transition: transform 0.2s ease;
+  color: #6b7280;
+`;
+
+const DropdownMenu = styled.div<{ $isOpen: boolean }>`
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: white;
+  border: 2px solid #e5e7eb;
+  border-radius: 8px;
+  box-shadow: 0 8px 25px rgba(0, 0, 0, 0.15);
+  z-index: 20;
+  max-height: 200px;
+  overflow-y: auto;
+  margin-top: 4px;
+  
+  display: ${props => props.$isOpen ? 'block' : 'none'};
+`;
+
+const DropdownItem = styled.button<{ $withColor?: string }>`
+  width: 100%;
+  padding: 12px 16px;
+  background: none;
+  border: none;
+  text-align: left;
+  cursor: pointer;
+  font-size: 14px;
+  font-weight: 500;
+  color: #374151;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  transition: background 0.2s ease;
+  
+  &:hover {
+    background: #f3f4f6;
+  }
+  
+  &:first-child {
+    border-radius: 6px 6px 0 0;
+  }
+  
+  &:last-child {
+    border-radius: 0 0 6px 6px;
+  }
+`;
+
+const ColorIndicator = styled.div<{ $color: string }>`
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: ${props => getColorValue(props.$color)};
+  border: 2px solid #e5e7eb;
+  flex-shrink: 0;
+`;
+
+// 사이즈 토글 스타일
+const SizeGrid = styled.div`
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+`;
+
+const SizeButton = styled.button<{ $selected: boolean; $soldOut: boolean }>`
+  padding: 8px 16px;
+  background: ${props => 
+    props.$soldOut ? '#f3f4f6' : 
+    props.$selected ? '#6366f1' : 'white'
+  };
+  color: ${props => 
+    props.$soldOut ? '#9ca3af' : 
+    props.$selected ? 'white' : '#374151'
+  };
+  border: 1px solid ${props => 
+    props.$soldOut ? '#e5e7eb' : 
+    props.$selected ? '#6366f1' : '#d1d5db'
+  };
+  border-radius: 6px;
+  font-size: 14px;
+  font-weight: 500;
+  cursor: ${props => props.$soldOut ? 'not-allowed' : 'pointer'};
+  transition: all 0.2s ease;
+  min-width: 60px;
+  
+  &:hover:not(:disabled) {
+    border-color: #6366f1;
+    background: ${props => props.$selected ? '#5856eb' : '#f8fafc'};
+  }
+`;
+
+// 색상 유틸리티 함수들
+const getColorValue = (colorName: string): string => {
+  const colorMap: Record<string, string> = {
+    'BLACK': '#000000',
+    'WHITE': '#ffffff',
+    'RED': '#ef4444',
+    'BLUE': '#3b82f6',
+    'GREEN': '#10b981',
+    'YELLOW': '#f59e0b',
+    'PINK': '#ec4899',
+    'PURPLE': '#8b5cf6',
+    'GRAY': '#6b7280',
+    'GREY': '#6b7280',
+    'BROWN': '#a3682a',
+    'NAVY': '#1e3a8a',
+    'BEIGE': '#f5f5dc',
+    'ORANGE': '#f97316',
+    'IVORY': '#f8f8f0',
+    'CREAM': '#fdf5e6',
+    'KHAKI': '#bdb76b',
+    'OLIVE': '#808000',
+    'MAROON': '#800000',
+    'SILVER': '#c0c0c0',
+    'GOLD': '#ffd700',
+    'TURQUOISE': '#40e0d0',
+    'CORAL': '#ff7f50',
+    'SALMON': '#fa8072',
+    'MINT': '#98fb98',
+    'LAVENDER': '#e6e6fa',
+    'ROSE': '#ffc0cb',
+    'BURGUNDY': '#800020',
+    'TEAL': '#008080',
+  };
+  
+  return colorMap[colorName.toUpperCase()] || '#6b7280';
+};
+
+
+// Props 인터페이스
+interface ModernOptionSelectorProps {
+  product: ProductDetail;
+  selectedOptions: SelectedOptions[];
+  selectedGender: "MEN" | "WOMEN" | "UNISEX" | null;
+  selectedColor: string | null;
+  onGenderSelect: (gender: "MEN" | "WOMEN" | "UNISEX") => void;
+  onColorSelect: (color: string) => void;
+  onSizeSelect: (optionId: number) => void;
+  getAvailableGenders: () => ("MEN" | "WOMEN" | "UNISEX")[];
+  getAvailableColors: () => string[];
+  getAvailableSizes: () => Array<{
+    optionId: number;
+    gender: "MEN" | "WOMEN" | "UNISEX";
+    size: string;
+    color: string;
+    stock: number;
+    sizeLabel: string;
+  }>;
+}
+
+const genderLabels: Record<"MEN" | "WOMEN" | "UNISEX", string> = {
+  MEN: "남성",
+  WOMEN: "여성", 
+  UNISEX: "공용"
+};
+
+export const ModernOptionSelector: React.FC<ModernOptionSelectorProps> = ({
+  product,
+  selectedOptions,
+  selectedGender,
+  selectedColor,
+  onGenderSelect,
+  onColorSelect,
+  onSizeSelect,
+  getAvailableGenders,
+  getAvailableColors,
+  getAvailableSizes,
+}) => {
+  const [isGenderDropdownOpen, setIsGenderDropdownOpen] = useState(false);
+  const [isColorDropdownOpen, setIsColorDropdownOpen] = useState(false);
+  const genderDropdownRef = React.useRef<HTMLDivElement>(null);
+  const colorDropdownRef = React.useRef<HTMLDivElement>(null);
+  
+  const availableGenders = getAvailableGenders();
+  const availableColors = getAvailableColors();
+  const availableSizes = getAvailableSizes();
+
+  // 외부 클릭 시 드롭다운 닫기
+  React.useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (genderDropdownRef.current && !genderDropdownRef.current.contains(event.target as Node)) {
+        setIsGenderDropdownOpen(false);
+      }
+      if (colorDropdownRef.current && !colorDropdownRef.current.contains(event.target as Node)) {
+        setIsColorDropdownOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, []);
+
+  // 성별이 하나만 있으면 자동 선택
+  React.useEffect(() => {
+    if (availableGenders.length === 1 && !selectedGender) {
+      onGenderSelect(availableGenders[0]);
+    }
+  }, [availableGenders, selectedGender, onGenderSelect]);
+
+  // 색상이 하나만 있으면 자동 선택
+  React.useEffect(() => {
+    if (selectedGender && availableColors.length === 1 && !selectedColor) {
+      onColorSelect(availableColors[0]);
+    }
+  }, [availableColors, selectedColor, selectedGender, onColorSelect]);
+
+  // 대체 UI (기본 옵션 표시)
+  if (availableGenders.length === 0 && product && product.options.length > 0) {
+    return (
+      <OptionContainer>
+        <OptionGroup>
+          <OptionLabel>옵션 선택</OptionLabel>
+          <SizeGrid>
+            {product.options.map((option) => {
+              const isSelected = selectedOptions.some(
+                (selected) => selected.optionId === option.optionId
+              );
+              const isSoldOut = option.stock === 0;
+
+              return (
+                <SizeButton
+                  key={option.optionId}
+                  $selected={isSelected}
+                  $soldOut={isSoldOut}
+                  onClick={() => !isSoldOut && onSizeSelect(option.optionId)}
+                  disabled={isSoldOut}
+                >
+                  {option.gender !== 'UNISEX' && `${option.gender === 'MEN' ? '남성' : '여성'} `}
+                  {option.color} {option.size}
+                  {isSoldOut && ' (품절)'}
+                </SizeButton>
+              );
+            })}
+          </SizeGrid>
+        </OptionGroup>
+      </OptionContainer>
+    );
+  }
+
+  return (
+    <OptionContainer>
+      <OptionsGrid>
+        {/* 성별 선택 - Dropdown */}
+        {availableGenders.length > 0 && (
+          <OptionGroup>
+            <OptionLabel>성별</OptionLabel>
+            <DropdownContainer ref={genderDropdownRef}>
+              <DropdownButton
+                onClick={() => setIsGenderDropdownOpen(!isGenderDropdownOpen)}
+                type="button"
+              >
+                <span>{selectedGender ? genderLabels[selectedGender] : '성별을 선택하세요'}</span>
+                <DropdownArrow $isOpen={isGenderDropdownOpen}>▼</DropdownArrow>
+              </DropdownButton>
+              
+              <DropdownMenu $isOpen={isGenderDropdownOpen}>
+                {availableGenders.map((gender) => (
+                  <DropdownItem
+                    key={gender}
+                    onClick={() => {
+                      onGenderSelect(gender);
+                      setIsGenderDropdownOpen(false);
+                    }}
+                    type="button"
+                  >
+                    {genderLabels[gender]}
+                  </DropdownItem>
+                ))}
+              </DropdownMenu>
+            </DropdownContainer>
+          </OptionGroup>
+        )}
+
+        {/* 색상 선택 - Dropdown */}
+        {selectedGender && availableColors.length > 0 && (
+          <OptionGroup>
+            <OptionLabel>색상</OptionLabel>
+            <DropdownContainer ref={colorDropdownRef}>
+              <DropdownButton
+                onClick={() => setIsColorDropdownOpen(!isColorDropdownOpen)}
+                type="button"
+              >
+                <div style={{ display: 'flex', alignItems: 'center', gap: '10px' }}>
+                  {selectedColor && <ColorIndicator $color={selectedColor} />}
+                  <span>{selectedColor || '색상을 선택하세요'}</span>
+                </div>
+                <DropdownArrow $isOpen={isColorDropdownOpen}>▼</DropdownArrow>
+              </DropdownButton>
+              
+              <DropdownMenu $isOpen={isColorDropdownOpen}>
+                {availableColors.map((color) => (
+                  <DropdownItem
+                    key={color}
+                    onClick={() => {
+                      onColorSelect(color);
+                      setIsColorDropdownOpen(false);
+                    }}
+                    type="button"
+                  >
+                    <ColorIndicator $color={color} />
+                    {color}
+                  </DropdownItem>
+                ))}
+              </DropdownMenu>
+            </DropdownContainer>
+          </OptionGroup>
+        )}
+      </OptionsGrid>
+
+      {/* 사이즈 선택 - 컴팩트 토글 */}
+      {selectedGender && selectedColor && availableSizes.length > 0 && (
+        <SizesSection>
+          <OptionLabel>사이즈</OptionLabel>
+          <SizeGrid>
+            {availableSizes.map((option) => {
+              const isSelected = selectedOptions.some(
+                (selected) => selected.optionId === option.optionId
+              );
+              const isSoldOut = option.stock === 0;
+
+              return (
+                <SizeButton
+                  key={option.optionId}
+                  $selected={isSelected}
+                  $soldOut={isSoldOut}
+                  onClick={() => !isSoldOut && onSizeSelect(option.optionId)}
+                  disabled={isSoldOut}
+                  type="button"
+                >
+                  {option.size}
+                  {isSoldOut && ' (품절)'}
+                </SizeButton>
+              );
+            })}
+          </SizeGrid>
+        </SizesSection>
+      )}
+    </OptionContainer>
+  );
+};

--- a/src/components/products/ProductCard.tsx
+++ b/src/components/products/ProductCard.tsx
@@ -30,6 +30,7 @@
 import React from "react"; // 컴포넌트 생성을 위한 핵심 React 라이브러리
 import { ProductListItem } from "types/products"; // 상품 목록 항목 데이터 구조를 위한 TypeScript 인터페이스
 import { toUrl } from "../../utils/common/images"; // 이미지 경로를 전체 URL로 변환하는 유틸리티 함수
+import { WishlistButton } from "./WishlistButton"; // 인터랙티브한 찜하기 버튼 컴포넌트
 import {
   ProductCard as StyledProductCard,
   ProductImage,
@@ -39,7 +40,6 @@ import {
   PriceSection,
   DiscountPrice,
   OriginalPrice,
-  WishCount,
 } from "../../pages/products/Lists.styles"; // 상품 카드 UI 요소를 위한 스타일된 컴포넌트
 
 /**
@@ -99,12 +99,13 @@ export const ProductCard: React.FC<ProductCardProps> = ({
           )}
         </PriceSection>
 
-        {/* 위시리스트 수 섹션 - 상품 인기도/소셜 증명 표시 */}
-        <WishCount>
-          <span>❤️</span> {/* 시각적 매력을 위한 하트 이모지 */}
-          <span>{product.wishNumber}</span>{" "}
-          {/* 이 상품을 위시리스트에 추가한 사용자 수 */}
-        </WishCount>
+        {/* 위시리스트 버튼 - 인터랙티브한 찜하기 기능과 소셜 증명 표시 */}
+        <WishlistButton
+          productId={product.productId}
+          wishCount={product.wishNumber}
+          size="small"
+          showCount={true}
+        />
       </ProductInfo>
     </StyledProductCard>
   );

--- a/src/components/products/ProductInfo.tsx
+++ b/src/components/products/ProductInfo.tsx
@@ -30,6 +30,7 @@
 
 import React from "react"; // 컴포넌트 생성을 위한 핵심 React 라이브러리
 import { ProductDetail } from "types/products"; // 상세 상품 데이터 구조를 위한 TypeScript 인터페이스
+import { WishlistButton } from "./WishlistButton"; // 인터랙티브한 찜하기 버튼 컴포넌트
 import {
   InfoSection,
   StoreName,
@@ -97,6 +98,14 @@ export const ProductInfo: React.FC<ProductInfoProps> = ({
         {/* 현재/할인된 가격 - 가장 눈에 띄는 가격 표시 */}
         <CurrentPrice>{formatPrice(product.discountPrice)}원</CurrentPrice>
       </PriceSection>
+
+      {/* 위시리스트 버튼 - 찜하기 기능과 찜한 사람 수 표시 */}
+      <WishlistButton
+        productId={product.productId}
+        wishCount={product.wishNumber}
+        size="medium"
+        showCount={true}
+      />
     </InfoSection>
   );
 };

--- a/src/components/products/SelectedOptions.tsx
+++ b/src/components/products/SelectedOptions.tsx
@@ -97,8 +97,10 @@ export const SelectedOptions: React.FC<SelectedOptionsProps> = ({
         <SelectedOptionItem key={option.optionId}>
           {/* 옵션 정보 섹션 - 사이즈와 재고 세부 정보 표시 */}
           <OptionInfo>
-            {/* 사이즈 표시 - 선택된 상품 사이즈 옵션 표시 */}
-            <SizeText>사이즈 {option.size}</SizeText>
+            {/* 옵션 표시 - 선택된 상품 옵션 정보 표시 */}
+            <SizeText>
+              {option.gender === "MEN" ? "남성" : option.gender === "WOMEN" ? "여성" : "공용"} / {option.color} / {option.size}
+            </SizeText>
 
             {/* 낮은 재고 경고가 있는 재고 정보 */}
             <StockInfo $lowStock={option.stock < 5}>

--- a/src/components/products/WishlistButton.tsx
+++ b/src/components/products/WishlistButton.tsx
@@ -1,0 +1,184 @@
+import React, { useState, useEffect } from "react";
+import styled from "styled-components";
+import { useWishlist } from "hooks/cart/useWishlist";
+import Warning from "components/modal/Warning";
+
+interface WishlistButtonProps {
+  productId: number;
+  wishCount: number;
+  showCount?: boolean;
+  size?: "small" | "medium" | "large";
+  className?: string;
+}
+
+const ButtonContainer = styled.div<{ size: string }>`
+  display: flex;
+  align-items: center;
+  gap: ${({ size }) => (size === "small" ? "4px" : size === "large" ? "8px" : "6px")};
+`;
+
+const HeartButton = styled.button<{ $isWishlisted: boolean; size: string; $isLoading: boolean }>`
+  background: none;
+  border: none;
+  cursor: ${({ $isLoading }) => ($isLoading ? "not-allowed" : "pointer")};
+  padding: ${({ size }) => (size === "small" ? "4px" : size === "large" ? "8px" : "6px")};
+  border-radius: 50%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.2s ease;
+  font-size: ${({ size }) => (size === "small" ? "1rem" : size === "large" ? "1.5rem" : "1.2rem")};
+  opacity: ${({ $isLoading }) => ($isLoading ? 0.6 : 1)};
+
+  &:hover:not(:disabled) {
+    background: rgba(0, 0, 0, 0.05);
+    transform: scale(1.1);
+  }
+
+  &:active {
+    transform: scale(0.95);
+  }
+
+  .heart-icon {
+    color: ${({ $isWishlisted }) => ($isWishlisted ? "#ef4444" : "#d1d5db")};
+    transition: color 0.2s ease;
+  }
+`;
+
+const WishCount = styled.span<{ size: string }>`
+  font-size: ${({ size }) => (size === "small" ? "0.875rem" : size === "large" ? "1.125rem" : "1rem")};
+  color: #6b7280;
+  font-weight: 500;
+  min-width: ${({ size }) => (size === "small" ? "20px" : "24px")};
+  text-align: left;
+`;
+
+export const WishlistButton: React.FC<WishlistButtonProps> = ({
+  productId,
+  wishCount,
+  showCount = true,
+  size = "medium",
+  className,
+}) => {
+  const { addToWishlist, removeFromWishlist, isWishlisted, loading } = useWishlist();
+  const [isLocalLoading, setIsLocalLoading] = useState(false);
+  const [localWishCount, setLocalWishCount] = useState(wishCount);
+  const [showAddModal, setShowAddModal] = useState(false);
+  const [showRemoveModal, setShowRemoveModal] = useState(false);
+  
+  const isWishlistedItem = isWishlisted(productId);
+  const isCurrentlyLoading = loading || isLocalLoading;
+
+  // wishCount prop이 변경되면 localWishCount 업데이트
+  useEffect(() => {
+    setLocalWishCount(wishCount);
+  }, [wishCount]);
+
+  const handleWishlistToggle = async (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    if (isCurrentlyLoading) return;
+
+    if (isWishlistedItem) {
+      setShowRemoveModal(true);
+    } else {
+      setShowAddModal(true);
+    }
+  };
+
+  const handleAddConfirm = async () => {
+    setShowAddModal(false);
+    setIsLocalLoading(true);
+    
+    // 낙관적 업데이트
+    setLocalWishCount(prev => prev + 1);
+    
+    try {
+      const success = await addToWishlist(productId);
+      if (!success) {
+        // 실패 시 롤백
+        setLocalWishCount(prev => prev - 1);
+      }
+    } catch (error) {
+      console.error("찜하기 추가 실패:", error);
+      // 실패 시 롤백
+      setLocalWishCount(prev => prev - 1);
+    } finally {
+      setIsLocalLoading(false);
+    }
+  };
+
+  const handleRemoveConfirm = async () => {
+    setShowRemoveModal(false);
+    setIsLocalLoading(true);
+    
+    // 낙관적 업데이트
+    setLocalWishCount(prev => Math.max(0, prev - 1));
+    
+    try {
+      const success = await removeFromWishlist(productId);
+      if (!success) {
+        // 실패 시 롤백
+        setLocalWishCount(prev => prev + 1);
+      }
+    } catch (error) {
+      console.error("찜하기 제거 실패:", error);
+      // 실패 시 롤백
+      setLocalWishCount(prev => prev + 1);
+    } finally {
+      setIsLocalLoading(false);
+    }
+  };
+
+  const handleCancel = () => {
+    setShowAddModal(false);
+    setShowRemoveModal(false);
+  };
+
+  return (
+    <ButtonContainer size={size} className={className}>
+      <HeartButton
+        onClick={handleWishlistToggle}
+        $isWishlisted={isWishlistedItem}
+        size={size}
+        $isLoading={isCurrentlyLoading}
+        disabled={isCurrentlyLoading}
+        title={isWishlistedItem ? "찜 해제" : "찜하기"}
+        aria-label={isWishlistedItem ? "찜 해제" : "찜하기"}
+      >
+        {isCurrentlyLoading ? (
+          <span className="heart-icon">⏳</span>
+        ) : (
+          <span className="heart-icon">
+            {isWishlistedItem ? "❤️" : "🤍"}
+          </span>
+        )}
+      </HeartButton>
+      
+      {showCount && (
+        <WishCount size={size}>
+          {localWishCount}
+        </WishCount>
+      )}
+
+      {/* 찜하기 확인 모달 */}
+      <Warning
+        open={showAddModal}
+        title="찜하기"
+        message="이 상품을 찜 목록에 추가하시겠습니까?"
+        onConfirm={handleAddConfirm}
+        onCancel={handleCancel}
+      />
+
+      {/* 찜 해제 확인 모달 */}
+      <Warning
+        open={showRemoveModal}
+        title="찜 해제"
+        message="이 상품을 찜 목록에서 제거하시겠습니까?"
+        onConfirm={handleRemoveConfirm}
+        onCancel={handleCancel}
+      />
+    </ButtonContainer>
+  );
+};

--- a/src/hooks/cart/useWishlist.ts
+++ b/src/hooks/cart/useWishlist.ts
@@ -1,0 +1,168 @@
+import { useState, useEffect, useCallback } from "react";
+import { WishlistService, WishlistResponse } from "../../api/wishlistService";
+import { useAuth } from "../../contexts/AuthContext";
+
+interface UseWishlistReturn {
+  // 찜한 상품 목록
+  wishlistItems: WishlistResponse | null;
+  
+  // 찜한 상품 개수
+  wishlistCount: number;
+  
+  // 찜한 상품 목록을 서버에서 다시 가져와서 업데이트하는 함수
+  fetchWishlist: (page?: number, size?: number) => Promise<void>;
+  
+  // 상품을 찜 목록에 추가하는 함수
+  addToWishlist: (productId: number) => Promise<boolean>;
+  
+  // 상품을 찜 목록에서 제거하는 함수
+  removeFromWishlist: (productId: number) => Promise<boolean>;
+  
+  // 특정 상품이 찜되어 있는지 확인하는 함수
+  isWishlisted: (productId: number) => boolean;
+  
+  // 로딩 상태
+  loading: boolean;
+  
+  // 에러 상태
+  error: string | null;
+}
+
+export const useWishlist = (): UseWishlistReturn => {
+  // 상태 관리
+  const [wishlistItems, setWishlistItems] = useState<WishlistResponse | null>(null);
+  const [wishlistCount, setWishlistCount] = useState<number>(0);
+  const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string | null>(null);
+  
+  // 인증 상태 가져오기
+  const { user } = useAuth();
+  
+  /**
+   * 서버에서 찜한 상품 목록을 가져와서 업데이트하는 함수
+   */
+  const fetchWishlist = useCallback(async (page: number = 0, size: number = 9): Promise<void> => {
+    // 로그인하지 않은 사용자는 찜 목록을 null로 설정
+    if (!user) {
+      setWishlistItems(null);
+      setWishlistCount(0);
+      setError(null);
+      return;
+    }
+    
+    try {
+      setLoading(true);
+      setError(null);
+      
+      // 서버에서 찜한 상품 목록 가져오기
+      const wishlistData = await WishlistService.getWishlist(page, size);
+      
+      setWishlistItems(wishlistData);
+      setWishlistCount(wishlistData.totalElements);
+    } catch (err: any) {
+      // 에러 발생 시 빈 상태로 설정
+      setWishlistItems(null);
+      setWishlistCount(0);
+      setError(err.message || "찜 목록을 불러오는데 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, [user]);
+  
+  /**
+   * 상품을 찜 목록에 추가하는 함수
+   */
+  const addToWishlist = useCallback(async (productId: number): Promise<boolean> => {
+    if (!user) {
+      setError("로그인이 필요합니다.");
+      return false;
+    }
+    
+    try {
+      setLoading(true);
+      setError(null);
+      
+      await WishlistService.addToWishlist(productId);
+      
+      // 찜 목록 새로고침
+      await fetchWishlist();
+      
+      return true;
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.message || err.message || "찜 추가에 실패했습니다.";
+      setError(errorMessage);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [user, fetchWishlist]);
+  
+  /**
+   * 상품을 찜 목록에서 제거하는 함수
+   */
+  const removeFromWishlist = useCallback(async (productId: number): Promise<boolean> => {
+    if (!user) {
+      setError("로그인이 필요합니다.");
+      return false;
+    }
+    
+    try {
+      setLoading(true);
+      setError(null);
+      
+      await WishlistService.removeFromWishlist(productId);
+      
+      // 찜 목록 새로고침
+      await fetchWishlist();
+      
+      return true;
+    } catch (err: any) {
+      const errorMessage = err.response?.data?.message || err.message || "찜 제거에 실패했습니다.";
+      setError(errorMessage);
+      return false;
+    } finally {
+      setLoading(false);
+    }
+  }, [user, fetchWishlist]);
+  
+  /**
+   * 특정 상품이 찜되어 있는지 확인하는 함수
+   */
+  const isWishlisted = useCallback((productId: number): boolean => {
+    if (!wishlistItems) return false;
+    return wishlistItems.wishlists.some(item => item.productId === productId);
+  }, [wishlistItems]);
+  
+  /**
+   * 컴포넌트 마운트 시 찜 목록 초기화
+   */
+  useEffect(() => {
+    fetchWishlist();
+  }, [fetchWishlist]);
+  
+  /**
+   * 로그인 상태 변경 시 찜 목록 재조회
+   */
+  useEffect(() => {
+    if (user) {
+      // 로그인한 경우 찜 목록 조회
+      fetchWishlist();
+    } else {
+      // 로그아웃한 경우 찜 목록 초기화
+      setWishlistItems(null);
+      setWishlistCount(0);
+      setError(null);
+    }
+  }, [user, fetchWishlist]);
+  
+  return {
+    wishlistItems,
+    wishlistCount,
+    fetchWishlist,
+    addToWishlist,
+    removeFromWishlist,
+    isWishlisted,
+    loading,
+    error,
+  };
+};

--- a/src/hooks/order/usePaymentData.ts
+++ b/src/hooks/order/usePaymentData.ts
@@ -133,6 +133,8 @@ export const usePaymentData = (): UsePaymentDataReturn => {
         const directOrderItems = locationState.directOrderItems.map((item: any) => ({
           id: `${item.productId}-${item.optionId}`,
           productName: item.productName,
+          gender: item.gender, // 성별 정보 추가
+          color: item.color,   // 색상 정보 추가
           size: item.size || "",
           discountPrice: item.discountPrice || item.price,
           productPrice: item.price || item.discountPrice,

--- a/src/hooks/products/useProductActions.ts
+++ b/src/hooks/products/useProductActions.ts
@@ -130,8 +130,9 @@ export const useProductActions = (
           productName: product.name,
           price: product.price,
           discountPrice: product.discountPrice,
-          size: productOption?.size || "",
-          color: productOption?.color || "",
+          gender: option.gender,                     // 성별 정보 추가
+          size: option.size,                         // 사이즈 정보 (이미 선택된 옵션에서 가져옴)
+          color: option.color,                       // 색상 정보 (이미 선택된 옵션에서 가져옴)
           imageUrl: product.images?.[0]?.url || "",
         };
       });

--- a/src/hooks/products/useProductList.ts
+++ b/src/hooks/products/useProductList.ts
@@ -2,13 +2,14 @@ import { useState, useEffect } from "react";
 import { useLocation } from "react-router-dom";
 import { ProductService } from "../../api/productService";
 import { ProductListItem } from "types/products";
+import { ProductFilters } from "../../components/products/FilterButtons";
 
 /**
  * 상품 목록 관리 훅
  *
- * 상품 목록 페이지에서 상품 데이터를 페이지네이션과 정렬 기능과 함께 관리합니다.
+ * 상품 목록 페이지에서 상품 데이터를 페이지네이션, 정렬, 필터링 기능과 함께 관리합니다.
  * 로딩, 에러 상태를 포함하여 안전하게 데이터를 처리하고,
- * 페이지 변경, 정렬 변경 및 재시도 기능을 제공합니다.
+ * 페이지 변경, 정렬 변경, 필터 변경 및 재시도 기능을 제공합니다.
  *
  * @param pageSize 페이지당 표시할 상품 수 (기본값: 9)
  */
@@ -27,12 +28,33 @@ export const useProductList = (pageSize: number = 9) => {
   const [totalPages, setTotalPages] = useState(0);
   // 현재 정렬 방식
   const [currentSort, setCurrentSort] = useState("latest");
+  // 현재 필터 상태
+  const [filters, setFilters] = useState<ProductFilters>({ sort: "latest" });
+
+  // URL에서 초기 필터 상태 설정
+  useEffect(() => {
+    const urlParams = getFilterParamsFromUrl();
+    const initialFilters: ProductFilters = {
+      sort: urlParams.sort || "latest",
+      categoryId: urlParams.categoryId,
+      minPrice: urlParams.minPrice,
+      maxPrice: urlParams.maxPrice,
+      storeId: urlParams.storeId,
+      colors: urlParams.colors,
+      sizes: urlParams.sizes,
+      genders: urlParams.genders,
+      inStockOnly: urlParams.inStockOnly,
+      discountedOnly: urlParams.discountedOnly,
+    };
+    setFilters(initialFilters);
+    setCurrentSort(urlParams.sort || "latest");
+  }, [location.search]);
 
   // URL에서 필터 파라미터 추출
   const getFilterParamsFromUrl = () => {
     const searchParams = new URLSearchParams(location.search);
     return {
-      q: searchParams.get("q") || undefined, // 검색 키워드 파라미터 추가
+      q: searchParams.get("q") || undefined,
       categoryId: searchParams.get("categoryId")
         ? Number(searchParams.get("categoryId"))
         : undefined,
@@ -45,6 +67,19 @@ export const useProductList = (pageSize: number = 9) => {
       storeId: searchParams.get("storeId")
         ? Number(searchParams.get("storeId"))
         : undefined,
+      colors: searchParams.get("colors")
+        ? searchParams.get("colors")!.split(",")
+        : undefined,
+      sizes: searchParams.get("sizes")
+        ? searchParams.get("sizes")!.split(",")
+        : undefined,
+      genders: searchParams.get("genders")
+        ? searchParams.get("genders")!.split(",")
+        : undefined,
+      inStockOnly:
+        searchParams.get("inStockOnly") === "true" ? true : undefined,
+      discountedOnly:
+        searchParams.get("discountedOnly") === "true" ? true : undefined,
       sort: searchParams.get("sort") || "latest",
     };
   };
@@ -53,30 +88,43 @@ export const useProductList = (pageSize: number = 9) => {
    * 서버에서 상품 목록을 불러오는 비동기 함수
    * @param page 불러올 페이지 번호 (0부터 시작, 기본값: 0)
    * @param sort 정렬 방식 (기본값: currentSort)
+   * @param customFilters 사용자 정의 필터 (선택적)
    */
-  const loadProducts = async (page: number = 0, sort?: string) => {
+  const loadProducts = async (
+    page: number = 0,
+    sort?: string,
+    customFilters?: ProductFilters
+  ) => {
     try {
       setLoading(true); // 로딩 시작
       setError(null); // 이전 에러 초기화
 
-      const filterParams = getFilterParamsFromUrl();
-      const sortParam = sort ?? filterParams.sort ?? currentSort;
+      // URL 파라미터와 필터 상태를 모두 고려한 파라미터 구성
+      const urlParams = getFilterParamsFromUrl();
+      const currentFilters = customFilters || filters;
+      const sortParam = sort || currentFilters.sort || currentSort;
 
-      // 모든 파라미터를 포함한 요청 파라미터 구성
-      const requestParamsBase = {
-        ...filterParams,
+      // 필터 파라미터를 API 형식에 맞게 변환
+      const processedFilters = {
+        ...urlParams,
+        ...currentFilters,
         page,
         size: pageSize,
         sort: sortParam,
       };
 
+      // undefined, null, 빈 문자열, 빈 배열 제거
       const requestParams = Object.fromEntries(
-        Object.entries(requestParamsBase).filter(
-          ([_, value]) => value !== undefined && value !== null
+        Object.entries(processedFilters).filter(
+          ([_, value]) =>
+            value !== undefined &&
+            value !== null &&
+            value !== "" &&
+            !(Array.isArray(value) && value.length === 0)
         )
       );
 
-      // 디버깅용 로그 (필요 없으면 주석 처리 가능)
+      // 디버깅용 로그
       console.log("API 호출 파라미터:", requestParams);
 
       // API 명세서에 따라 /api/products 엔드포인트에 필터/정렬/페이지 파라미터 전달
@@ -87,6 +135,11 @@ export const useProductList = (pageSize: number = 9) => {
       setTotalPages(response.totalPages || 0);
       setCurrentPage(page);
       setCurrentSort(sortParam);
+
+      // 필터 상태 업데이트
+      if (customFilters) {
+        setFilters(customFilters);
+      }
     } catch (err: any) {
       console.error("상품 목록 로딩 실패:", err);
       // 에러 발생 시 에러 메시지 설정
@@ -113,7 +166,18 @@ export const useProductList = (pageSize: number = 9) => {
    * @param sort 새로운 정렬 방식
    */
   const handleSortChange = (sort: string) => {
+    const newFilters = { ...filters, sort };
+    setFilters(newFilters);
     loadProducts(0, sort); // 정렬 변경 시 첫 페이지부터 로드
+  };
+
+  /**
+   * 필터 변경을 처리하는 함수
+   * @param newFilters 새로운 필터 상태
+   */
+  const handleFiltersChange = (newFilters: ProductFilters) => {
+    setFilters(newFilters);
+    loadProducts(0, newFilters.sort, newFilters); // 필터 변경 시 첫 페이지부터 로드
   };
 
   /**
@@ -128,10 +192,21 @@ export const useProductList = (pageSize: number = 9) => {
     loadProducts(0);
   }, []);
 
-  // URL이 변경될 때마다 상품 목록 다시 로드
+  // 필터가 변경될 때마다 상품 목록 다시 로드 (URL 변경 포함)
   useEffect(() => {
-    loadProducts(0);
-  }, [location.search]);
+    // 필터가 초기 상태가 아니거나, 명시적으로 변경된 경우에만 로드
+    const hasFilters = Object.keys(filters).some(
+      (key) =>
+        key !== "sort" && filters[key as keyof ProductFilters] !== undefined
+    );
+
+    if (hasFilters || filters.sort !== "latest") {
+      loadProducts(0);
+    } else if (Object.keys(filters).length === 1 && filters.sort === "latest") {
+      // 필터 초기화 시에도 로드 (기본 상태로 복원)
+      loadProducts(0);
+    }
+  }, [filters]);
 
   // 상품 목록 관련 모든 상태와 함수를 반환
   return {
@@ -141,9 +216,11 @@ export const useProductList = (pageSize: number = 9) => {
     currentPage, // 현재 페이지 번호
     totalPages, // 전체 페이지 수
     currentSort, // 현재 정렬 방식
+    filters, // 현재 필터 상태
     loadProducts, // 상품 로드 함수
     handlePageChange, // 페이지 변경 처리 함수
     handleSortChange, // 정렬 변경 처리 함수
+    handleFiltersChange, // 필터 변경 처리 함수
     retry, // 재시도 함수
   };
 };

--- a/src/hooks/seller/useDashboardStats.ts
+++ b/src/hooks/seller/useDashboardStats.ts
@@ -1,0 +1,156 @@
+import { useState, useEffect, useCallback } from "react";
+import { OrderService } from "../../api/orderService";
+
+export interface DashboardStats {
+  todaySales: number;
+  weeklySales: number; // 전체 매출 대신 주간 매출
+  newOrdersCount: number;
+  totalOrdersCount: number;
+  shippingCount: number;
+  deliveredCount: number; // 배송 완료 건수 추가
+  newReviewsCount: number;
+  totalReviewsCount: number;
+}
+
+export interface RecentOrder {
+  orderId: number;
+  productName: string;
+  finalPrice: number;
+  status: string;
+  orderedAt: string;
+  imageUrl: string;
+}
+
+export const useDashboardStats = () => {
+  const [stats, setStats] = useState<DashboardStats>({
+    todaySales: 0,
+    weeklySales: 0,
+    newOrdersCount: 0,
+    totalOrdersCount: 0,
+    shippingCount: 0,
+    deliveredCount: 0,
+    newReviewsCount: 0,
+    totalReviewsCount: 0,
+  });
+  const [recentOrders, setRecentOrders] = useState<RecentOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const formatStatusText = (status: string): string => {
+    switch (status) {
+      case "ORDERED":
+        return "주문완료";
+      case "SHIPPED":
+        return "배송중";
+      case "DELIVERED":
+        return "배송완료";
+      case "CANCELLED":
+        return "주문취소";
+      case "RETURNED":
+        return "반품";
+      default:
+        return status;
+    }
+  };
+
+  const isToday = (dateString: string): boolean => {
+    const today = new Date();
+    const orderDate = new Date(dateString);
+
+    return (
+      today.getFullYear() === orderDate.getFullYear() &&
+      today.getMonth() === orderDate.getMonth() &&
+      today.getDate() === orderDate.getDate()
+    );
+  };
+
+  const isThisWeek = (dateString: string): boolean => {
+    const today = new Date();
+    const orderDate = new Date(dateString);
+    const oneWeekAgo = new Date(today.getTime() - 7 * 24 * 60 * 60 * 1000);
+
+    return orderDate >= oneWeekAgo && orderDate <= today;
+  };
+
+  const fetchDashboardData = useCallback(async () => {
+    try {
+      setLoading(true);
+      setError(null);
+
+      const ordersResponse = await OrderService.getSellerOrders(0, 1000, "ALL");
+      const allOrders = ordersResponse.content;
+
+      // 오늘 날짜 필터링
+      const todayOrders = allOrders.filter((order) => isToday(order.orderedAt));
+
+      // 이번 주 주문 필터링
+      const weeklyOrders = allOrders.filter((order) =>
+        isThisWeek(order.orderedAt)
+      );
+
+      // 통계 계산
+      const todaySales = todayOrders.reduce(
+        (sum, order) => sum + order.finalPrice,
+        0
+      );
+      const weeklySales = weeklyOrders.reduce(
+        (sum, order) => sum + order.finalPrice,
+        0
+      );
+      const newOrdersCount = todayOrders.length;
+      const totalOrdersCount = allOrders.length;
+      const shippingCount = allOrders.filter(
+        (order) => order.status === "SHIPPED"
+      ).length;
+      const deliveredCount = allOrders.filter(
+        (order) => order.status === "DELIVERED"
+      ).length;
+
+      // Mock 데이터 - 실제 리뷰 API가 없으므로
+      const newReviewsCount = 5;
+      const totalReviewsCount = 20;
+
+      setStats({
+        todaySales,
+        weeklySales,
+        newOrdersCount,
+        totalOrdersCount,
+        shippingCount,
+        deliveredCount,
+        newReviewsCount,
+        totalReviewsCount,
+      });
+
+      // 최근 주문 4개 (최신순)
+      const recentOrdersData: RecentOrder[] = allOrders
+        .slice(0, 4)
+        .map((order) => ({
+          orderId: order.orderId,
+          productName: order.items[0]?.productName || "상품명 없음",
+          finalPrice: order.finalPrice,
+          status: formatStatusText(order.status),
+          orderedAt: order.orderedAt,
+          imageUrl: order.items[0]?.imageUrl || "",
+        }));
+
+      setRecentOrders(recentOrdersData);
+    } catch (err) {
+      console.error("Dashboard data fetch error:", err);
+      setError("대시보드 데이터를 불러오는데 실패했습니다.");
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchDashboardData();
+  }, [fetchDashboardData]);
+
+  return {
+    stats,
+    recentOrders,
+    loading,
+    error,
+    refetch: fetchDashboardData,
+  };
+};

--- a/src/pages/auth/LoginPage.tsx
+++ b/src/pages/auth/LoginPage.tsx
@@ -1,7 +1,7 @@
 import { useAuth } from "../../contexts/AuthContext";
 import { useEffect, useState } from "react";
 import styled from "styled-components";
-import { Link, useNavigate } from "react-router-dom";
+import { Link, useNavigate, useLocation } from "react-router-dom";
 import { validateEmail } from "../../utils/auth/auth";
 import axios from "axios";
 import {
@@ -101,6 +101,7 @@ export default function LoginPage() {
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const navigate = useNavigate();
+  const location = useLocation();
   const isEmailValid = validateEmail(email);
   const { login: authLogin } = useAuth();
 
@@ -113,6 +114,14 @@ export default function LoginPage() {
       setIsRecaptchaReady(true);
     }
   }, [executeRecaptcha]);
+
+  // 소셜 로그인 콜백에서 전달된 에러 처리
+  useEffect(() => {
+    const state = location.state as { error?: string } | null;
+    if (state?.error) {
+      setError(state.error);
+    }
+  }, [location.state]);
 
   const handleSubmit = async (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
@@ -156,7 +165,7 @@ export default function LoginPage() {
       const loginData = response.data.data;
       if (loginData && loginData.token) {
         // authLogin 함수를 4개의 인자를 받도록 수정 (name 추가)
-        await authLogin(
+        authLogin(
           loginData.nickname,
           loginData.name || loginData.nickname,
           loginData.role,
@@ -181,6 +190,17 @@ export default function LoginPage() {
     } finally {
       setLoading(false);
     }
+  };
+
+  // 소셜 로그인 핸들러
+  const handleGoogleLogin = () => {
+    const baseURL = process.env.REACT_APP_API_URL || "https://localhost:8443";
+    window.location.href = `${baseURL}/oauth2/authorization/google`;
+  };
+
+  const handleKakaoLogin = () => {
+    const baseURL = process.env.REACT_APP_API_URL || "https://localhost:8443";
+    window.location.href = `${baseURL}/oauth2/authorization/kakao`;
   };
 
   return (
@@ -245,8 +265,8 @@ export default function LoginPage() {
 
         <SocialLoginButton
           type="button"
-          // alert() 대신 console.log로 변경
-          onClick={() => console.log("구글 로그인 연동 필요")}
+          onClick={handleGoogleLogin}
+          disabled={loading}
         >
           <i className="fab fa-google" style={{ color: "#DB4437" }}></i>
           구글로 로그인
@@ -254,8 +274,8 @@ export default function LoginPage() {
 
         <SocialLoginButton
           type="button"
-          // alert() 대신 console.log로 변경
-          onClick={() => console.log("카카오 로그인 연동 필요")}
+          onClick={handleKakaoLogin}
+          disabled={loading}
         >
           <i className="fas fa-comment" style={{ color: "#FEE500" }}></i>
           카카오로 로그인

--- a/src/pages/auth/SocialCallbackPage.tsx
+++ b/src/pages/auth/SocialCallbackPage.tsx
@@ -1,0 +1,130 @@
+import { useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useAuth } from "../../contexts/AuthContext";
+import styled from "styled-components";
+
+const CallbackContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 100vh;
+  background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+  color: white;
+`;
+
+const LoadingSpinner = styled.div`
+  width: 50px;
+  height: 50px;
+  border: 5px solid rgba(255, 255, 255, 0.3);
+  border-top: 5px solid white;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 20px;
+
+  @keyframes spin {
+    0% {
+      transform: rotate(0deg);
+    }
+    100% {
+      transform: rotate(360deg);
+    }
+  }
+`;
+
+const Message = styled.h2`
+  text-align: center;
+  margin-bottom: 10px;
+`;
+
+const SubMessage = styled.p`
+  text-align: center;
+  opacity: 0.8;
+`;
+
+export default function SocialCallbackPage() {
+  const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const { login: authLogin } = useAuth();
+
+  useEffect(() => {
+    const handleSocialLoginCallback = async () => {
+      try {
+        // React Router의 useSearchParams 사용
+        // 일반적인 OAuth2 콜백 파라미터들
+        let token =
+          searchParams.get("token") ||
+          searchParams.get("access_token") ||
+          searchParams.get("jwt");
+        let email = searchParams.get("email") || searchParams.get("username");
+        let name = searchParams.get("name") || searchParams.get("displayName");
+        let nickname =
+          searchParams.get("nickname") ||
+          searchParams.get("name") ||
+          searchParams.get("given_name");
+        let provider =
+          searchParams.get("provider") || searchParams.get("social_provider");
+        let role =
+          searchParams.get("role") || searchParams.get("userType") || "user";
+
+        // 에러 처리를 위한 파라미터
+        const error = searchParams.get("error");
+        const errorDescription = searchParams.get("error_description");
+
+        // 에러가 있는 경우 처리
+        if (error) {
+          throw new Error(
+            `소셜 로그인 실패: ${error} ${
+              errorDescription ? `- ${errorDescription}` : ""
+            }`
+          );
+        }
+
+        // Authorization Code가 있는 경우 (OAuth2 표준 플로우)
+        const code = searchParams.get("code");
+        const state = searchParams.get("state");
+
+        if (code && !token) {
+          throw new Error(
+            "Authorization Code 방식은 아직 구현되지 않았습니다. 백엔드에서 직접 JWT 토큰을 전달해주세요."
+          );
+        }
+
+        if (!token || !email) {
+          throw new Error(
+            `필수 로그인 정보가 누락되었습니다. token: ${!!token}, email: ${!!email}`
+          );
+        }
+
+        // AuthContext의 login 함수 호출
+        authLogin(
+          nickname || email, // nickname이 없으면 email 사용
+          name || nickname || email, // name이 없으면 nickname 또는 email 사용
+          role as "user" | "admin" | "seller",
+          token
+        );
+
+        // 홈페이지로 리다이렉트
+        navigate("/", { replace: true });
+      } catch (error: any) {
+        // 에러 발생 시 로그인 페이지로 리다이렉트 (에러 메시지와 함께)
+        navigate("/login", {
+          replace: true,
+          state: {
+            error: error.message || "소셜 로그인 처리 중 오류가 발생했습니다.",
+          },
+        });
+      }
+    };
+
+    handleSocialLoginCallback();
+  }, [navigate, authLogin, searchParams]);
+
+  return (
+    <CallbackContainer>
+      <LoadingSpinner />
+      <Message>소셜 로그인 처리 중...</Message>
+      <SubMessage>잠시만 기다려 주세요.</SubMessage>
+    </CallbackContainer>
+  );
+}

--- a/src/pages/products/DetailPage.tsx
+++ b/src/pages/products/DetailPage.tsx
@@ -10,7 +10,7 @@ import { useProductActions } from "../../hooks/products/useProductActions"; // �
 // 상품 상세 UI 컴포넌트들
 import { ProductImages } from "../../components/products/ProductImages"; // 상품 이미지 슬라이더
 import { ProductInfo } from "../../components/products/ProductInfo"; // 상품 기본 정보 (이름, 가격 등)
-import { SizeSelector } from "../../components/products/SizeSelector"; // 사이즈 선택 컴포넌트
+import { ModernOptionSelector } from "../../components/products/ModernOptionSelector"; // 모던 옵션 선택 컴포넌트 (성별, 색상, 사이즈)
 import { SelectedOptions } from "../../components/products/SelectedOptions"; // 선택된 옵션 표시 및 수량 조절
 import { ProductDescription } from "../../components/products/ProductDescription"; // 상품 상세 설명
 import { ProductReviews } from "../../components/review/ProductReviews"; // 상품 리뷰 섹션
@@ -59,13 +59,20 @@ const DetailPage: React.FC = () => {
 
   // 상품 옵션 선택 및 관리 훅
   const {
-    selectedOptions,      // 현재 선택된 옵션들 (사이즈, 수량 포함)
+    selectedOptions,      // 현재 선택된 옵션들 (성별, 색상, 사이즈, 수량 포함)
+    selectedGender,       // 선택된 성별
+    selectedColor,        // 선택된 색상
+    handleGenderSelect,   // 성별 선택 핸들러
+    handleColorSelect,    // 색상 선택 핸들러
     handleSizeSelect,     // 사이즈 선택 핸들러
     handleQuantityChange, // 수량 변경 핸들러
     handleRemoveOption,   // 선택된 옵션 제거 핸들러
     clearSelectedOptions, // 모든 선택 옵션 초기화
     getTotalQuantity,     // 전체 선택 수량 계산
     getTotalPrice,        // 전체 선택 가격 계산
+    getAvailableGenders,  // 선택 가능한 성별 목록
+    getAvailableColors,   // 선택 가능한 색상 목록
+    getAvailableSizes,    // 선택 가능한 사이즈 목록
   } = useProductOptions(product);
 
   // 장바구니 및 주문 액션 관리 훅
@@ -137,11 +144,18 @@ const DetailPage: React.FC = () => {
             getDiscountRate={() => getDiscountRate(product)}
           />
 
-          {/* 사이즈 선택 컴포넌트 */}
-          <SizeSelector
+          {/* 모던 옵션 선택 컴포넌트 (성별, 색상, 사이즈) */}
+          <ModernOptionSelector
             product={product}
             selectedOptions={selectedOptions}
+            selectedGender={selectedGender}
+            selectedColor={selectedColor}
+            onGenderSelect={handleGenderSelect}
+            onColorSelect={handleColorSelect}
             onSizeSelect={(optionId) => handleSizeSelect(optionId, handleError)}
+            getAvailableGenders={getAvailableGenders}
+            getAvailableColors={getAvailableColors}
+            getAvailableSizes={getAvailableSizes}
           />
 
           {/* 선택된 옵션 표시 및 수량 조절 */}

--- a/src/pages/seller/SellerMyPage.tsx
+++ b/src/pages/seller/SellerMyPage.tsx
@@ -1,10 +1,23 @@
 import React, { useState, useEffect } from "react";
 import * as echarts from "echarts";
 import SellerOrdersPage from "../order/SellerOrdersPage";
+import SellerProductManagePage from "./SellerProductManagePage";
+import StoreService from "../../api/storeService";
+import { SellerStore } from "../../types/products";
+import { toUrl } from "utils/common/images";
+import { useDashboardStats } from "../../hooks/seller/useDashboardStats";
 
 const SellerMyPage: React.FC = () => {
   const [activeMenu, setActiveMenu] = useState("dashboard");
   const [selectedPeriod, setSelectedPeriod] = useState("일간");
+  const [storeInfo, setStoreInfo] = useState<SellerStore | null>(null);
+  const [loading, setLoading] = useState(true);
+  const {
+    stats,
+    recentOrders,
+    loading: statsLoading,
+    error: statsError,
+  } = useDashboardStats();
 
   const generateChartData = (
     period: string
@@ -12,17 +25,22 @@ const SellerMyPage: React.FC = () => {
     let xAxisData: string[] = [];
     let seriesData: number[] = [];
 
+    // Mock 데이터로 현실적인 매출 패턴 생성
+    // 실제 API가 준비되면 대체 가능
     switch (period) {
       case "일간":
         xAxisData = ["09:00", "12:00", "15:00", "18:00", "21:00"];
+        // 일반적인 일일 매출 패턴: 오후와 저녁에 높은 매출
         seriesData = [120000, 180000, 150000, 280000, 220000];
         break;
       case "주간":
         xAxisData = ["월", "화", "수", "목", "금", "토", "일"];
+        // 주말에 높은 매출 패턴
         seriesData = [850000, 920000, 880000, 950000, 1020000, 1150000, 980000];
         break;
       case "월간":
         xAxisData = ["1주", "2주", "3주", "4주"];
+        // 월 말에 높은 매출 패턴 (급여일 후 소비 증가)
         seriesData = [3800000, 4200000, 3900000, 4500000];
         break;
     }
@@ -31,6 +49,23 @@ const SellerMyPage: React.FC = () => {
   };
 
   useEffect(() => {
+    const fetchStoreInfo = async () => {
+      try {
+        const store = await StoreService.getSellerStore();
+        setStoreInfo(store);
+      } catch (error) {
+        console.error("가게 정보 로드 실패:", error);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStoreInfo();
+  }, []);
+
+  useEffect(() => {
+    // 대시보드가 활성 상태일 때만 차트 생성
+    if (activeMenu !== "dashboard") return;
     const chartDom = document.getElementById("salesChart");
     if (!chartDom) return;
 
@@ -121,7 +156,7 @@ const SellerMyPage: React.FC = () => {
     return () => {
       myChart.dispose();
     };
-  }, [selectedPeriod]);
+  }, [selectedPeriod, activeMenu]); // activeMenu 의존성 추가
 
   return (
     <div className="min-h-screen bg-gradient-to-br from-white via-blue-50 to-purple-100">
@@ -132,10 +167,22 @@ const SellerMyPage: React.FC = () => {
           <div className="p-6 border-b border-gray-200">
             <div className="flex items-center space-x-3">
               <div className="w-12 h-12 bg-gradient-to-br from-blue-400 to-purple-400 rounded-full flex items-center justify-center">
-                <i className="fas fa-user text-white text-lg"></i>
+                {storeInfo?.logo ? (
+                  <img
+                    src={toUrl(storeInfo.logo)}
+                    alt="가게 로고"
+                    className="w-full h-full object-cover rounded-full"
+                  />
+                ) : (
+                  <i className="fas fa-store text-white text-lg"></i>
+                )}
               </div>
               <div>
-                <h3 className="text-gray-800 font-semibold">스마트 펫샵</h3>
+                <h3 className="text-gray-800 font-semibold">
+                  {loading
+                    ? "로딩 중..."
+                    : storeInfo?.storeName || "가게명 없음"}
+                </h3>
                 <div className="flex items-center space-x-1">
                   <div className="flex text-yellow-500">
                     <i className="fas fa-star text-xs"></i>
@@ -198,6 +245,8 @@ const SellerMyPage: React.FC = () => {
         <main className="flex-1">
           {activeMenu === "orders" ? (
             <SellerOrdersPage />
+          ) : activeMenu === "products" ? (
+            <SellerProductManagePage />
           ) : (
             <div className="p-8">
               <div className="max-w-7xl mx-auto">
@@ -207,70 +256,115 @@ const SellerMyPage: React.FC = () => {
                     대시보드
                   </h2>
                   <p className="text-gray-600">
-                    스마트한 쇼핑 경험을 위한 최고의 선택
+                    {loading
+                      ? "정보를 불러오는 중..."
+                      : storeInfo?.description || "가게 설명이 없습니다."}
                   </p>
                 </div>
 
                 {/* Stats Cards */}
                 <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
-                  {[
-                    {
-                      title: "오늘의 매출",
-                      value: "₩2,450,000",
-                      change: "+12.5%",
-                      icon: "fas fa-won-sign",
-                      color: "from-green-400 to-green-600",
-                    },
-                    {
-                      title: "신규 주문",
-                      value: "24",
-                      change: "+8.2%",
-                      icon: "fas fa-shopping-bag",
-                      color: "from-blue-400 to-blue-600",
-                    },
-                    {
-                      title: "배송 중",
-                      value: "18",
-                      change: "-2.1%",
-                      icon: "fas fa-truck",
-                      color: "from-orange-400 to-orange-600",
-                    },
-                    {
-                      title: "문의/리뷰",
-                      value: "7",
-                      change: "+15.3%",
-                      icon: "fas fa-comment",
-                      color: "from-purple-400 to-purple-600",
-                    },
-                  ].map((stat, index) => (
-                    <div
-                      key={index}
-                      className="bg-white rounded-xl p-6 border border-gray-100 shadow-sm"
-                    >
-                      <div className="flex items-center justify-between mb-4">
-                        <div
-                          className={`w-12 h-12 bg-gradient-to-br ${stat.color} rounded-lg flex items-center justify-center`}
-                        >
-                          <i className={`${stat.icon} text-white text-lg`}></i>
+                  {statsLoading ? (
+                    // Loading skeleton
+                    Array.from({ length: 4 }).map((_, index) => (
+                      <div
+                        key={index}
+                        className="bg-white rounded-xl p-6 border border-gray-100 shadow-sm animate-pulse"
+                      >
+                        <div className="flex items-center justify-between mb-4">
+                          <div className="w-12 h-12 bg-gray-200 rounded-lg"></div>
+                          <div className="w-16 h-4 bg-gray-200 rounded"></div>
                         </div>
-                        <span
-                          className={`text-sm font-medium ${
-                            stat.change.startsWith("+")
-                              ? "text-green-600"
-                              : "text-red-600"
-                          }`}
-                        >
-                          {stat.change}
-                        </span>
+                        <div className="w-20 h-4 bg-gray-200 rounded mb-1"></div>
+                        <div className="w-24 h-8 bg-gray-200 rounded"></div>
                       </div>
-                      <h3 className="text-gray-600 text-sm mb-1">
-                        {stat.title}
-                      </h3>
-                      <p className="text-2xl font-bold text-gray-800">
-                        {stat.value}
-                      </p>
+                    ))
+                  ) : statsError ? (
+                    <div className="col-span-4 text-center text-red-600 py-8">
+                      {statsError}
                     </div>
-                  ))}
+                  ) : (
+                    [
+                      {
+                        title: "매출 현황",
+                        mainLabel: "오늘",
+                        mainValue: `₩${stats.todaySales.toLocaleString()}`,
+                        subLabel: "이번 주",
+                        subValue: `₩${stats.weeklySales.toLocaleString()}`,
+                        icon: "fas fa-won-sign",
+                        color: "from-green-400 to-green-600",
+                      },
+                      {
+                        title: "주문 현황",
+                        mainLabel: "신규",
+                        mainValue: stats.newOrdersCount.toString(),
+                        subLabel: "전체",
+                        subValue: stats.totalOrdersCount.toString(),
+                        icon: "fas fa-shopping-bag",
+                        color: "from-blue-400 to-blue-600",
+                      },
+                      {
+                        title: "배송 현황",
+                        mainLabel: "배송 중",
+                        mainValue: stats.shippingCount.toString(),
+                        subLabel: "배송 완료",
+                        subValue: stats.deliveredCount.toString(),
+                        icon: "fas fa-truck",
+                        color: "from-orange-400 to-orange-600",
+                      },
+                      {
+                        title: "리뷰 현황",
+                        mainLabel: "신규",
+                        mainValue: stats.newReviewsCount.toString(),
+                        subLabel: "전체",
+                        subValue: stats.totalReviewsCount.toString(),
+                        icon: "fas fa-star",
+                        color: "from-purple-400 to-purple-600",
+                      },
+                    ].map((stat, index) => (
+                      <div
+                        key={index}
+                        className="bg-white rounded-xl p-6 border border-gray-100 shadow-sm"
+                      >
+                        <div className="flex items-center justify-between mb-4">
+                          <div
+                            className={`w-12 h-12 bg-gradient-to-br ${stat.color} rounded-lg flex items-center justify-center`}
+                          >
+                            <i
+                              className={`${stat.icon} text-white text-lg`}
+                            ></i>
+                          </div>
+                        </div>
+                        <h3 className="text-gray-600 text-sm mb-3 font-medium">
+                          {stat.title}
+                        </h3>
+
+                        {/* 주요 지표 */}
+                        <div className="mb-3">
+                          <div className="flex items-center justify-between mb-1">
+                            <span className="text-xs text-gray-500">
+                              {stat.mainLabel}
+                            </span>
+                          </div>
+                          <p className="text-2xl font-bold text-gray-800">
+                            {stat.mainValue}
+                          </p>
+                        </div>
+
+                        {/* 보조 지표 */}
+                        <div className="pt-3 border-t border-gray-100">
+                          <div className="flex items-center justify-between">
+                            <span className="text-xs text-gray-500">
+                              {stat.subLabel}
+                            </span>
+                            <span className="text-sm font-semibold text-gray-600">
+                              {stat.subValue}
+                            </span>
+                          </div>
+                        </div>
+                      </div>
+                    ))
+                  )}
                 </div>
 
                 {/* Charts and Recent Activity */}
@@ -309,52 +403,78 @@ const SellerMyPage: React.FC = () => {
                       최근 주문
                     </h3>
                     <div className="space-y-4">
-                      {[
-                        {
-                          id: "#12345",
-                          product: "프리미엄 강아지 사료 2kg",
-                          amount: "₩45,000",
-                          status: "배송중",
-                        },
-                        {
-                          id: "#12346",
-                          product: "고양이 장난감 세트",
-                          amount: "₩28,000",
-                          status: "주문완료",
-                        },
-                        {
-                          id: "#12347",
-                          product: "펫 캐리어 백",
-                          amount: "₩85,000",
-                          status: "배송준비",
-                        },
-                        {
-                          id: "#12348",
-                          product: "강아지 목줄 세트",
-                          amount: "₩32,000",
-                          status: "배송중",
-                        },
-                      ].map((order) => (
-                        <div
-                          key={order.id}
-                          className="flex items-center justify-between p-4 bg-gray-50 rounded-lg"
-                        >
-                          <div className="flex-1">
-                            <p className="text-gray-800 font-medium text-sm">
-                              {order.product}
-                            </p>
-                            <p className="text-gray-500 text-xs">{order.id}</p>
+                      {statsLoading ? (
+                        // Loading skeleton for recent orders
+                        Array.from({ length: 4 }).map((_, index) => (
+                          <div
+                            key={index}
+                            className="flex items-center justify-between p-4 bg-gray-50 rounded-lg animate-pulse"
+                          >
+                            <div className="flex-1">
+                              <div className="w-48 h-4 bg-gray-200 rounded mb-1"></div>
+                              <div className="w-16 h-3 bg-gray-200 rounded"></div>
+                            </div>
+                            <div className="text-right">
+                              <div className="w-20 h-4 bg-gray-200 rounded mb-1"></div>
+                              <div className="w-16 h-5 bg-gray-200 rounded"></div>
+                            </div>
                           </div>
-                          <div className="text-right">
-                            <p className="text-gray-800 font-semibold text-sm">
-                              {order.amount}
-                            </p>
-                            <span className="inline-block px-2 py-1 text-xs bg-blue-100 text-blue-600 rounded-full">
-                              {order.status}
-                            </span>
-                          </div>
+                        ))
+                      ) : recentOrders.length === 0 ? (
+                        <div className="text-center py-8 text-gray-500">
+                          <i className="fas fa-shopping-cart text-4xl mb-4 text-gray-300"></i>
+                          <p>최근 주문이 없습니다.</p>
                         </div>
-                      ))}
+                      ) : (
+                        recentOrders.map((order) => (
+                          <div
+                            key={order.orderId}
+                            className="flex items-center justify-between p-4 bg-gray-50 rounded-lg"
+                          >
+                            <div className="flex items-center space-x-3 flex-1">
+                              {order.imageUrl && (
+                                <img
+                                  src={toUrl(order.imageUrl)}
+                                  alt={order.productName}
+                                  className="w-12 h-12 object-cover rounded-lg"
+                                  onError={(e) => {
+                                    e.currentTarget.src = toUrl(
+                                      "images/common/no-image.png"
+                                    );
+                                  }}
+                                />
+                              )}
+                              <div className="flex-1">
+                                <p className="text-gray-800 font-medium text-sm">
+                                  {order.productName}
+                                </p>
+                                <p className="text-gray-500 text-xs">
+                                  #{order.orderId}
+                                </p>
+                                <p className="text-gray-400 text-xs">
+                                  {new Date(order.orderedAt).toLocaleDateString(
+                                    "ko-KR",
+                                    {
+                                      month: "short",
+                                      day: "numeric",
+                                      hour: "2-digit",
+                                      minute: "2-digit",
+                                    }
+                                  )}
+                                </p>
+                              </div>
+                            </div>
+                            <div className="text-right">
+                              <p className="text-gray-800 font-semibold text-sm">
+                                ₩{order.finalPrice.toLocaleString()}
+                              </p>
+                              <span className="inline-block px-2 py-1 text-xs bg-blue-100 text-blue-600 rounded-full">
+                                {order.status}
+                              </span>
+                            </div>
+                          </div>
+                        ))
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/pages/seller/SellerProductManagePage.tsx
+++ b/src/pages/seller/SellerProductManagePage.tsx
@@ -1,0 +1,1686 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from "react";
+import { ProductService } from "../../api/productService";
+import {
+  ProductListItem,
+  Category,
+  CreateProductRequest,
+  UpdateProductRequest,
+  ProductImageRequest,
+  ProductOptionRequest,
+  ColorType,
+  SizeType,
+  COLOR_LABELS,
+  SIZE_LABELS,
+} from "../../types/products";
+import { Container, Header, Title } from "../products/Lists.styles";
+import styled from "styled-components";
+import { toUrl } from "utils/common/images";
+import Warning from "../../components/modal/Warning";
+
+// 스타일 컴포넌트들
+const ManagementContainer = styled(Container)`
+  padding-top: 80px; // Header 높이만큼 여백 추가
+`;
+
+const ActionButton = styled.button<{
+  variant?: "primary" | "danger" | "secondary";
+}>`
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  border: 1px solid;
+  font-weight: 500;
+
+  ${(props) =>
+    props.variant === "primary" &&
+    `
+    background: #3b82f6;
+    color: white;
+    border-color: #3b82f6;
+    
+    &:hover {
+      background: #2563eb;
+      border-color: #2563eb;
+    }
+  `}
+
+  ${(props) =>
+    props.variant === "danger" &&
+    `
+    background: #ef4444;
+    color: white;
+    border-color: #ef4444;
+    
+    &:hover {
+      background: #dc2626;
+      border-color: #dc2626;
+    }
+  `}
+  
+  ${(props) =>
+    props.variant === "secondary" &&
+    `
+    background: white;
+    color: #374151;
+    border-color: #d1d5db;
+    
+    &:hover {
+      background: #f3f4f6;
+      border-color: #9ca3af;
+    }
+  `}
+`;
+
+const Card = styled.div`
+  background: white;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  overflow: hidden;
+`;
+
+const TableContainer = styled(Card)`
+  overflow-x: auto;
+`;
+
+const Table = styled.table`
+  width: 100%;
+  border-collapse: collapse;
+`;
+
+const TableHeader = styled.thead`
+  background: #f8fafc;
+`;
+
+const TableHeaderCell = styled.th`
+  padding: 12px 16px;
+  text-align: left;
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: #6b7280;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+`;
+
+const TableRow = styled.tr`
+  border-bottom: 1px solid #f1f5f9;
+
+  &:hover {
+    background: #f8fafc;
+  }
+`;
+
+const TableCell = styled.td`
+  padding: 16px;
+  vertical-align: middle;
+`;
+
+const ProductInfo = styled.div`
+  display: flex;
+  align-items: center;
+  gap: 12px;
+`;
+
+const ProductImage = styled.img`
+  width: 64px;
+  height: 64px;
+  border-radius: 8px;
+  object-fit: cover;
+  flex-shrink: 0;
+`;
+
+const ProductDetails = styled.div`
+  flex: 1;
+`;
+
+const ProductName = styled.div`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 4px;
+  line-height: 1.25;
+`;
+
+const ProductId = styled.div`
+  font-size: 0.75rem;
+  color: #6b7280;
+`;
+
+const PriceInfo = styled.div`
+  text-align: right;
+`;
+
+const Price = styled.div`
+  font-size: 0.875rem;
+  font-weight: 600;
+  color: #1f2937;
+`;
+
+const DiscountPrice = styled.div`
+  font-size: 0.75rem;
+  color: #ef4444;
+  margin-top: 2px;
+`;
+
+const ActionButtons = styled.div`
+  display: flex;
+  gap: 8px;
+`;
+
+const Modal = styled.div`
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+  padding: 16px;
+`;
+
+const ModalContent = styled.div`
+  background: white;
+  border-radius: 12px;
+  width: 100%;
+  max-width: 900px;
+  max-height: 90vh;
+  overflow-y: auto;
+  box-shadow: 0 10px 25px rgba(0, 0, 0, 0.25);
+`;
+
+const ModalHeader = styled.div`
+  padding: 24px 24px 0 24px;
+  border-bottom: 1px solid #f1f5f9;
+  margin-bottom: 24px;
+`;
+
+const ModalTitle = styled.h2`
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 16px;
+`;
+
+const ModalBody = styled.div`
+  padding: 0 24px 24px 24px;
+`;
+
+const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+`;
+
+const FormSection = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+`;
+
+const FormRow = styled.div`
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+
+  @media (max-width: 768px) {
+    grid-template-columns: 1fr;
+  }
+`;
+
+const FormGroup = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+`;
+
+const Label = styled.label`
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: #374151;
+`;
+
+const RequiredLabel = styled(Label)`
+  &:after {
+    content: " *";
+    color: #ef4444;
+  }
+`;
+
+const Input = styled.input`
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  transition: border-color 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+`;
+
+const Select = styled.select`
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  background: white;
+  transition: border-color 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+`;
+
+const TextArea = styled.textarea`
+  padding: 10px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  font-size: 0.875rem;
+  resize: vertical;
+  min-height: 100px;
+  transition: border-color 0.2s ease;
+
+  &:focus {
+    outline: none;
+    border-color: #3b82f6;
+    box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.1);
+  }
+`;
+
+const SectionTitle = styled.h3`
+  font-size: 1.125rem;
+  font-weight: 600;
+  color: #1f2937;
+  margin-bottom: 16px;
+  padding-bottom: 8px;
+  border-bottom: 2px solid #e5e7eb;
+`;
+
+const ImageGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 16px;
+  margin-bottom: 16px;
+`;
+
+const ImageCard = styled.div<{ $isMain?: boolean }>`
+  border: 2px solid ${(props) => (props.$isMain ? "#3b82f6" : "#e5e7eb")};
+  border-radius: 8px;
+  padding: 16px;
+  background: ${(props) => (props.$isMain ? "#eff6ff" : "#f9fafb")};
+  transition: border-color 0.2s ease;
+`;
+
+const ImagePreview = styled.div`
+  width: 100%;
+  height: 120px;
+  border: 2px dashed #d1d5db;
+  border-radius: 6px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  margin-bottom: 12px;
+  background: white;
+  overflow: hidden;
+
+  img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+  }
+`;
+
+const FileInput = styled.input`
+  display: none;
+`;
+
+const FileButton = styled.button`
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: white;
+  color: #374151;
+  font-size: 0.875rem;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-bottom: 8px;
+
+  &:hover {
+    background: #f3f4f6;
+    border-color: #9ca3af;
+  }
+`;
+
+const ImageTypeRow = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+  margin-bottom: 8px;
+`;
+
+const RadioGroup = styled.div`
+  display: flex;
+  gap: 12px;
+  align-items: center;
+`;
+
+const RadioLabel = styled.label`
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.875rem;
+  color: #374151;
+  cursor: pointer;
+`;
+
+const OptionCard = styled.div`
+  padding: 16px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #f9fafb;
+  margin-bottom: 12px;
+`;
+
+const OptionHeader = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 12px;
+`;
+
+const OptionGrid = styled.div`
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+  gap: 12px;
+`;
+
+const RemoveButton = styled.button`
+  color: #ef4444;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 1rem;
+  padding: 4px;
+  border-radius: 4px;
+  transition: background-color 0.2s ease;
+
+  &:hover {
+    color: #dc2626;
+    background: #fee2e2;
+  }
+`;
+
+const AddButton = styled(ActionButton)`
+  align-self: flex-start;
+`;
+
+const ModalFooter = styled.div`
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+  padding: 16px 24px;
+  border-top: 1px solid #f1f5f9;
+`;
+
+const EmptyState = styled.div`
+  text-align: center;
+  padding: 48px 16px;
+  color: #6b7280;
+`;
+
+const EmptyIcon = styled.div`
+  font-size: 3rem;
+  margin-bottom: 16px;
+  color: #d1d5db;
+`;
+
+const LoadingState = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+  color: #6b7280;
+
+  i {
+    margin-right: 8px;
+  }
+`;
+
+const ErrorText = styled.div`
+  color: #ef4444;
+  font-size: 0.875rem;
+  margin-top: 4px;
+`;
+
+// 페이지네이션 스타일
+const PaginationContainer = styled.div`
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-top: 24px;
+  padding: 0 16px;
+`;
+
+const PaginationInfo = styled.div`
+  color: #6b7280;
+  font-size: 0.875rem;
+`;
+
+const PaginationButtons = styled.div`
+  display: flex;
+  gap: 8px;
+  align-items: center;
+`;
+
+const PaginationButton = styled.button<{
+  $active?: boolean;
+  $disabled?: boolean;
+}>`
+  padding: 8px 12px;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  background: ${(props) => (props.$active ? "#3b82f6" : "white")};
+  color: ${(props) => (props.$active ? "white" : "#374151")};
+  font-size: 0.875rem;
+  cursor: ${(props) => (props.$disabled ? "not-allowed" : "pointer")};
+  opacity: ${(props) => (props.$disabled ? 0.5 : 1)};
+  transition: all 0.2s ease;
+
+  &:hover:not(:disabled) {
+    background: ${(props) => (props.$active ? "#2563eb" : "#f3f4f6")};
+    border-color: ${(props) => (props.$active ? "#2563eb" : "#9ca3af")};
+  }
+
+  &:disabled {
+    cursor: not-allowed;
+  }
+`;
+
+const PageNumbers = styled.div`
+  display: flex;
+  gap: 4px;
+`;
+
+// 상품 등록/수정 모달 컴포넌트
+interface ProductModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onSave: (productData: CreateProductRequest) => void;
+  editProduct?: ProductListItem | null;
+  categories: Category[];
+  isSaving?: boolean;
+}
+
+const ProductModal: React.FC<ProductModalProps> = ({
+  isOpen,
+  onClose,
+  onSave,
+  editProduct,
+  categories,
+  isSaving = false,
+}) => {
+  const [formData, setFormData] = useState<CreateProductRequest>({
+    name: "",
+    price: 0,
+    categoryId: categories[0]?.categoryId || 1,
+    description: "",
+    discountType: "NONE",
+    discountValue: 0,
+    images: [{ url: "", isMain: true, displayOrder: 1, type: "MAIN" }],
+    options: [{ gender: "UNISEX", color: "BLACK", size: "SIZE_260", stock: 0 }],
+  });
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [warningOpen, setWarningOpen] = useState(false);
+  const [warningMessage, setWarningMessage] = useState("");
+  const fileInputRefs = useRef<(HTMLInputElement | null)[]>([]);
+
+  // 사용된 옵션 조합을 추적
+  const getUsedCombinations = (): string[] => {
+    return formData.options.map(
+      (option) => `${option.gender}-${option.color}-${option.size}`
+    );
+  };
+
+  // 옵션이 이미 사용되었는지 확인
+  const isOptionUsed = (
+    gender: string,
+    color: ColorType,
+    size: SizeType,
+    excludeIndex?: number
+  ): boolean => {
+    const combination = `${gender}-${color}-${size}`;
+    return formData.options.some(
+      (option, index) =>
+        index !== excludeIndex &&
+        `${option.gender}-${option.color}-${option.size}` === combination
+    );
+  };
+
+  // 수정 모드일 때 폼 데이터 초기화
+  useEffect(() => {
+    const loadProductDetail = async () => {
+      if (editProduct) {
+        try {
+          // 상품 상세 정보 로드
+          const productDetail = await ProductService.getProduct(editProduct.productId);
+          
+          // 이미지 정보 구성
+          const images: ProductImageRequest[] = productDetail.images.map((img, index) => ({
+            url: img.url,
+            isMain: index === 0 || img.type === "MAIN",
+            displayOrder: index + 1,
+            type: img.type as "MAIN" | "DETAIL",
+            imageId: img.imageId
+          }));
+
+          // 첫 번째 이미지가 없으면 기본 이미지 추가
+          if (images.length === 0) {
+            images.push({
+              url: productDetail.images.length > 0 ? productDetail.images[0].url : "",
+              isMain: true,
+              displayOrder: 1,
+              type: "MAIN" as "MAIN" | "DETAIL",
+              imageId: productDetail.images.length > 0 ? productDetail.images[0].imageId : undefined
+            });
+          }
+
+          // 옵션 정보 구성 - 사이즈 값을 SIZE_ 접두어 형태로 변환
+          const options: ProductOptionRequest[] = productDetail.options.map(option => ({
+            optionId: option.optionId,
+            gender: option.gender,
+            color: option.color as ColorType,
+            size: `SIZE_${option.size}` as SizeType,
+            stock: option.stock
+          }));
+
+          // 할인 타입 변환
+          let discountType: "RATE_DISCOUNT" | "FIXED_DISCOUNT" | "NONE" = "NONE";
+          if (productDetail.discountType === "RATE_DISCOUNT") {
+            discountType = "RATE_DISCOUNT";
+          } else if (productDetail.discountType === "FIXED_DISCOUNT") {
+            discountType = "FIXED_DISCOUNT";
+          }
+
+          setFormData({
+            name: productDetail.name,
+            price: productDetail.price,
+            categoryId: productDetail.categoryType ? 
+              categories.find(cat => cat.type === productDetail.categoryType)?.categoryId || categories[0]?.categoryId || 1 :
+              categories[0]?.categoryId || 1,
+            description: productDetail.description,
+            discountType: discountType,
+            discountValue: productDetail.discountValue || 0,
+            images: images,
+            options: options.length > 0 ? options : [
+              { gender: "UNISEX", color: "BLACK", size: "SIZE_260", stock: 0 }
+            ],
+          });
+        } catch (error) {
+          console.error("상품 상세 정보 로드 실패:", error);
+          // 오류 시 기본값으로 설정
+          setFormData({
+            name: editProduct.name,
+            price: editProduct.price,
+            categoryId: categories[0]?.categoryId || 1,
+            description: "",
+            discountType: "NONE",
+            discountValue: 0,
+            images: [
+              {
+                url: editProduct.mainImageUrl,
+                isMain: true,
+                displayOrder: 1,
+                type: "MAIN",
+              },
+            ],
+            options: [
+              { gender: "UNISEX", color: "BLACK", size: "SIZE_260", stock: 10 },
+            ],
+          });
+        }
+      } else {
+        // 새 상품 등록 모드
+        setFormData({
+          name: "",
+          price: 0,
+          categoryId: categories[0]?.categoryId || 1,
+          description: "",
+          discountType: "NONE",
+          discountValue: 0,
+          images: [{ url: "", isMain: true, displayOrder: 1, type: "MAIN" }],
+          options: [
+            { gender: "UNISEX", color: "BLACK", size: "SIZE_260", stock: 0 },
+          ],
+        });
+      }
+      setErrors({});
+    };
+
+    loadProductDetail();
+  }, [editProduct, categories]);
+
+  const validateForm = (): boolean => {
+    const newErrors: Record<string, string> = {};
+
+    if (!formData.name.trim()) newErrors.name = "상품명을 입력해주세요.";
+    if (formData.price < 1000)
+      newErrors.price = "가격은 1000원 이상이어야 합니다.";
+    if (!formData.description.trim())
+      newErrors.description = "상품 설명을 입력해주세요.";
+
+    // 이미지 검증 로직 수정
+    const validImages = formData.images.filter(img => img.file || img.url);
+    if (validImages.length === 0) {
+      newErrors.images = "최소 1개의 이미지가 필요합니다.";
+    } else {
+      // 유효한 이미지 중에서 메인 이미지 체크
+      if (!validImages.some((img) => img.isMain)) {
+        newErrors.mainImage = "메인 이미지를 선택해주세요.";
+      }
+    }
+
+    if (formData.options.length === 0)
+      newErrors.options = "최소 1개의 옵션이 필요합니다.";
+
+    // 옵션 검증
+    formData.options.forEach((option, index) => {
+      if (option.stock < 0)
+        newErrors[`option-${index}-stock`] = "재고는 0 이상이어야 합니다.";
+    });
+
+    setErrors(newErrors);
+    return Object.keys(newErrors).length === 0;
+  };
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (validateForm()) {
+      onSave(formData);
+    }
+  };
+
+  const handleFileSelect = (index: number, file: File) => {
+    if (file && file.type.startsWith("image/")) {
+      const reader = new FileReader();
+      reader.onload = (e) => {
+        const updatedImages = [...formData.images];
+        updatedImages[index] = {
+          ...updatedImages[index],
+          url: e.target?.result as string,
+          file: file,
+        };
+        setFormData({ ...formData, images: updatedImages });
+      };
+      reader.readAsDataURL(file);
+    }
+  };
+
+  const addImage = () => {
+    const newDisplayOrder =
+      Math.max(...formData.images.map((img) => img.displayOrder)) + 1;
+    const newImages: ProductImageRequest[] = [
+      ...formData.images,
+      {
+        url: "",
+        isMain: false,
+        displayOrder: newDisplayOrder,
+        type: "DETAIL" as "MAIN" | "DETAIL",
+      },
+    ];
+    
+    // 첫 번째 이미지는 항상 메인으로 설정
+    if (newImages.length > 0) {
+      newImages[0].isMain = true;
+      newImages.slice(1).forEach(img => img.isMain = false);
+    }
+    
+    setFormData({ ...formData, images: newImages });
+  };
+
+  const updateImage = (
+    index: number,
+    field: keyof ProductImageRequest,
+    value: any
+  ) => {
+    const updatedImages = [...formData.images];
+
+    // 메인 이미지 설정 시 다른 이미지들의 메인 상태 해제
+    if (field === "isMain" && value === true) {
+      updatedImages.forEach((img, i) => {
+        if (i !== index) img.isMain = false;
+      });
+    }
+
+    updatedImages[index] = { ...updatedImages[index], [field]: value };
+    setFormData({ ...formData, images: updatedImages });
+  };
+
+  const removeImage = (index: number) => {
+    if (formData.images.length > 1) {
+      const updatedImages = formData.images.filter((_, i) => i !== index);
+
+      // 첫 번째 이미지는 항상 메인으로 설정
+      if (updatedImages.length > 0) {
+        updatedImages[0].isMain = true;
+        updatedImages.slice(1).forEach(img => img.isMain = false);
+      }
+
+      setFormData({ ...formData, images: updatedImages });
+    }
+  };
+
+  const addOption = () => {
+    // 사용 가능한 조합 찾기
+    const usedCombinations = getUsedCombinations();
+    const genders: ("MEN" | "WOMEN" | "UNISEX")[] = ["MEN", "WOMEN", "UNISEX"];
+    const colors = Object.keys(COLOR_LABELS) as ColorType[];
+    const sizes = Object.keys(SIZE_LABELS) as SizeType[];
+
+    let availableOption = null;
+
+    for (const gender of genders) {
+      for (const color of colors) {
+        for (const size of sizes) {
+          const combination = `${gender}-${color}-${size}`;
+          if (!usedCombinations.includes(combination)) {
+            availableOption = { gender, color, size, stock: 0 };
+            break;
+          }
+        }
+        if (availableOption) break;
+      }
+      if (availableOption) break;
+    }
+
+    if (availableOption) {
+      setFormData({
+        ...formData,
+        options: [...formData.options, availableOption],
+      });
+    } else {
+      setWarningMessage("더 이상 추가할 수 있는 옵션 조합이 없습니다.");
+      setWarningOpen(true);
+    }
+  };
+
+  // 실시간 옵션 중복 검증
+  const validateOptionCombination = useCallback((newOption: ProductOptionRequest, excludeIndex?: number) => {
+    const duplicateExists = formData.options.some((option, index) =>
+      index !== excludeIndex &&
+      option.gender === newOption.gender &&
+      option.size === newOption.size &&
+      option.color === newOption.color
+    );
+
+    if (duplicateExists) {
+      setWarningMessage("이미 존재하는 옵션 조합입니다.");
+      setWarningOpen(true);
+      return false;
+    }
+    return true;
+  }, [formData.options]);
+
+  const updateOption = (
+    index: number,
+    field: keyof ProductOptionRequest,
+    value: any
+  ) => {
+    const updatedOptions = [...formData.options];
+    const newOption = { ...updatedOptions[index], [field]: value };
+    
+    // 실시간 중복 검증
+    if (!validateOptionCombination(newOption, index)) {
+      return; // 중복이면 업데이트하지 않음
+    }
+    
+    updatedOptions[index] = newOption;
+    setFormData({ ...formData, options: updatedOptions });
+  };
+
+  const removeOption = (index: number) => {
+    if (formData.options.length > 1) {
+      const updatedOptions = formData.options.filter((_, i) => i !== index);
+      setFormData({ ...formData, options: updatedOptions });
+    }
+  };
+
+  // 사용 가능한 옵션 필터링
+  const getAvailableOptions = (
+    currentIndex: number,
+    field: "gender" | "color" | "size"
+  ) => {
+    const currentOption = formData.options[currentIndex];
+
+    if (field === "gender") {
+      return ["MEN", "WOMEN", "UNISEX"].filter(
+        (gender) =>
+          !isOptionUsed(
+            gender,
+            currentOption.color,
+            currentOption.size,
+            currentIndex
+          )
+      );
+    } else if (field === "color") {
+      return Object.keys(COLOR_LABELS).filter(
+        (color) =>
+          !isOptionUsed(
+            currentOption.gender,
+            color as ColorType,
+            currentOption.size,
+            currentIndex
+          )
+      );
+    } else {
+      // size
+      return Object.keys(SIZE_LABELS).filter(
+        (size) =>
+          !isOptionUsed(
+            currentOption.gender,
+            currentOption.color,
+            size as SizeType,
+            currentIndex
+          )
+      );
+    }
+  };
+
+  if (!isOpen) return null;
+
+  return (
+    <Modal onClick={(e) => e.target === e.currentTarget && onClose()}>
+      <ModalContent>
+        <ModalHeader>
+          <ModalTitle>{editProduct ? "상품 수정" : "상품 등록"}</ModalTitle>
+        </ModalHeader>
+
+        <ModalBody>
+          <Form onSubmit={handleSubmit}>
+            {/* 기본 정보 */}
+            <FormSection>
+              <SectionTitle>기본 정보</SectionTitle>
+              <FormRow>
+                <FormGroup>
+                  <RequiredLabel>상품명</RequiredLabel>
+                  <Input
+                    type="text"
+                    value={formData.name}
+                    onChange={(e) =>
+                      setFormData({ ...formData, name: e.target.value })
+                    }
+                    placeholder="상품명을 입력하세요"
+                  />
+                  {errors.name && <ErrorText>{errors.name}</ErrorText>}
+                </FormGroup>
+
+                <FormGroup>
+                  <RequiredLabel>가격 (원)</RequiredLabel>
+                  <Input
+                    type="number"
+                    value={formData.price}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        price: Number(e.target.value),
+                      })
+                    }
+                    min="1000"
+                    placeholder="1000"
+                  />
+                  {errors.price && <ErrorText>{errors.price}</ErrorText>}
+                </FormGroup>
+              </FormRow>
+
+              <FormRow>
+                <FormGroup>
+                  <RequiredLabel>카테고리</RequiredLabel>
+                  <Select
+                    value={formData.categoryId}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        categoryId: Number(e.target.value),
+                      })
+                    }
+                  >
+                    {categories.map((category) => (
+                      <option
+                        key={category.categoryId}
+                        value={category.categoryId}
+                      >
+                        {category.name}
+                      </option>
+                    ))}
+                  </Select>
+                </FormGroup>
+
+                <FormGroup>
+                  <Label>할인 타입</Label>
+                  <Select
+                    value={formData.discountType}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        discountType: e.target.value as
+                          | "RATE_DISCOUNT"
+                          | "FIXED_DISCOUNT"
+                          | "NONE",
+                      })
+                    }
+                  >
+                    <option value="NONE">없음</option>
+                    <option value="RATE_DISCOUNT">퍼센트 할인</option>
+                    <option value="FIXED_DISCOUNT">금액 할인</option>
+                  </Select>
+                </FormGroup>
+              </FormRow>
+
+              {formData.discountType !== "NONE" && (
+                <FormGroup>
+                  <Label>할인 값</Label>
+                  <Input
+                    type="number"
+                    value={formData.discountValue}
+                    onChange={(e) =>
+                      setFormData({
+                        ...formData,
+                        discountValue: Number(e.target.value),
+                      })
+                    }
+                    min="0"
+                    placeholder={
+                      formData.discountType === "RATE_DISCOUNT" ? "10" : "5000"
+                    }
+                  />
+                </FormGroup>
+              )}
+
+              <FormGroup>
+                <RequiredLabel>상품 설명</RequiredLabel>
+                <TextArea
+                  value={formData.description}
+                  onChange={(e) =>
+                    setFormData({ ...formData, description: e.target.value })
+                  }
+                  placeholder="상품에 대한 자세한 설명을 입력하세요"
+                />
+                {errors.description && (
+                  <ErrorText>{errors.description}</ErrorText>
+                )}
+              </FormGroup>
+            </FormSection>
+
+            {/* 이미지 관리 */}
+            <FormSection>
+              <SectionTitle>상품 이미지</SectionTitle>
+              <ImageGrid>
+                {formData.images.map((image, index) => (
+                  <ImageCard key={index} $isMain={image.isMain}>
+                    <ImagePreview>
+                      {image.url ? (
+                        <img
+                          src={toUrl(image.url)}
+                          alt={`상품 이미지 ${index + 1}`}
+                        />
+                      ) : (
+                        <div style={{ color: "#9ca3af", textAlign: "center" }}>
+                          <i
+                            className="fas fa-image"
+                            style={{ fontSize: "2rem", marginBottom: "8px" }}
+                          ></i>
+                          <div>이미지를 선택하세요</div>
+                        </div>
+                      )}
+                    </ImagePreview>
+
+                    <FileInput
+                      ref={(el) => {
+                        fileInputRefs.current[index] = el;
+                      }}
+                      type="file"
+                      accept="image/*"
+                      onChange={(e) => {
+                        const file = e.target.files?.[0];
+                        if (file) handleFileSelect(index, file);
+                      }}
+                    />
+
+                    <FileButton
+                      type="button"
+                      onClick={() => fileInputRefs.current[index]?.click()}
+                    >
+                      <i
+                        className="fas fa-upload"
+                        style={{ marginRight: "8px" }}
+                      ></i>
+                      이미지 선택
+                    </FileButton>
+
+                    <ImageTypeRow>
+                      <RadioGroup>
+                        <RadioLabel>
+                          <input
+                            type="radio"
+                            name={`image-type-${index}`}
+                            checked={image.type === "MAIN"}
+                            onChange={() => updateImage(index, "type", "MAIN")}
+                          />
+                          메인 이미지
+                        </RadioLabel>
+                        <RadioLabel>
+                          <input
+                            type="radio"
+                            name={`image-type-${index}`}
+                            checked={image.type === "DETAIL"}
+                            onChange={() =>
+                              updateImage(index, "type", "DETAIL")
+                            }
+                          />
+                          디테일 이미지
+                        </RadioLabel>
+                      </RadioGroup>
+
+                      {formData.images.length > 1 && (
+                        <RemoveButton
+                          type="button"
+                          onClick={() => removeImage(index)}
+                        >
+                          <i className="fas fa-times"></i>
+                        </RemoveButton>
+                      )}
+                    </ImageTypeRow>
+
+                  </ImageCard>
+                ))}
+              </ImageGrid>
+
+              <AddButton type="button" variant="secondary" onClick={addImage}>
+                <i className="fas fa-plus" style={{ marginRight: "8px" }}></i>
+                이미지 추가
+              </AddButton>
+              {errors.images && <ErrorText>{errors.images}</ErrorText>}
+              {errors.mainImage && <ErrorText>{errors.mainImage}</ErrorText>}
+            </FormSection>
+
+            {/* 옵션 관리 */}
+            <FormSection>
+              <SectionTitle>상품 옵션</SectionTitle>
+              {formData.options.map((option, index) => (
+                <OptionCard key={index}>
+                  <OptionHeader>
+                    <Label>옵션 {index + 1}</Label>
+                    {formData.options.length > 1 && (
+                      <RemoveButton
+                        type="button"
+                        onClick={() => removeOption(index)}
+                      >
+                        <i className="fas fa-times"></i>
+                      </RemoveButton>
+                    )}
+                  </OptionHeader>
+
+                  <OptionGrid>
+                    <FormGroup>
+                      <Label>성별</Label>
+                      <Select
+                        value={option.gender}
+                        onChange={(e) =>
+                          updateOption(index, "gender", e.target.value)
+                        }
+                      >
+                        {getAvailableOptions(index, "gender").map((gender) => (
+                          <option key={gender} value={gender}>
+                            {gender === "MEN"
+                              ? "남성"
+                              : gender === "WOMEN"
+                              ? "여성"
+                              : "공용"}
+                          </option>
+                        ))}
+                      </Select>
+                    </FormGroup>
+
+                    <FormGroup>
+                      <Label>색상</Label>
+                      <Select
+                        value={option.color}
+                        onChange={(e) =>
+                          updateOption(index, "color", e.target.value)
+                        }
+                      >
+                        {getAvailableOptions(index, "color").map((color) => (
+                          <option key={color} value={color}>
+                            {COLOR_LABELS[color as ColorType]}
+                          </option>
+                        ))}
+                      </Select>
+                    </FormGroup>
+
+                    <FormGroup>
+                      <Label>사이즈</Label>
+                      <Select
+                        value={option.size}
+                        onChange={(e) =>
+                          updateOption(index, "size", e.target.value)
+                        }
+                      >
+                        {getAvailableOptions(index, "size").map((size) => (
+                          <option key={size} value={size}>
+                            {SIZE_LABELS[size as SizeType]}
+                          </option>
+                        ))}
+                      </Select>
+                    </FormGroup>
+
+                    <FormGroup>
+                      <Label>재고 수량</Label>
+                      <Input
+                        type="number"
+                        value={option.stock}
+                        onChange={(e) =>
+                          updateOption(index, "stock", Number(e.target.value))
+                        }
+                        min="0"
+                        placeholder="0"
+                      />
+                      {errors[`option-${index}-stock`] && (
+                        <ErrorText>{errors[`option-${index}-stock`]}</ErrorText>
+                      )}
+                    </FormGroup>
+                  </OptionGrid>
+                </OptionCard>
+              ))}
+
+              <AddButton type="button" variant="secondary" onClick={addOption}>
+                <i className="fas fa-plus" style={{ marginRight: "8px" }}></i>
+                옵션 추가
+              </AddButton>
+              {errors.options && <ErrorText>{errors.options}</ErrorText>}
+            </FormSection>
+          </Form>
+        </ModalBody>
+
+        <ModalFooter>
+          <ActionButton type="button" variant="secondary" onClick={onClose}>
+            취소
+          </ActionButton>
+          <ActionButton 
+            type="submit" 
+            variant="primary" 
+            onClick={handleSubmit}
+            disabled={isSaving}
+          >
+            {isSaving ? (
+              <>
+                <i className="fas fa-spinner" style={{ marginRight: "8px" }}></i>
+                {editProduct ? "수정 중..." : "등록 중..."}
+              </>
+            ) : (
+              editProduct ? "수정" : "등록"
+            )}
+          </ActionButton>
+        </ModalFooter>
+      </ModalContent>
+      
+      {/* Warning Modal */}
+      <Warning
+        open={warningOpen}
+        title="알림"
+        message={warningMessage}
+        onConfirm={() => setWarningOpen(false)}
+        onCancel={() => setWarningOpen(false)}
+      />
+    </Modal>
+  );
+};
+
+// 메인 상품 관리 페이지 컴포넌트
+const SellerProductManagePage: React.FC = () => {
+  const [products, setProducts] = useState<ProductListItem[]>([]);
+  const [categories, setCategories] = useState<Category[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [editProduct, setEditProduct] = useState<ProductListItem | null>(null);
+  const [deleteWarningOpen, setDeleteWarningOpen] = useState(false);
+  const [productToDelete, setProductToDelete] = useState<number | null>(null);
+  const [isSaving, setIsSaving] = useState(false);
+  const [successMessage, setSuccessMessage] = useState("");
+  const [errorMessage, setErrorMessage] = useState("");
+  const [showSuccessModal, setShowSuccessModal] = useState(false);
+  const [showErrorModal, setShowErrorModal] = useState(false);
+
+  // 페이지네이션 상태
+  const [currentPage, setCurrentPage] = useState(0);
+  const [totalPages, setTotalPages] = useState(0);
+  const [totalElements, setTotalElements] = useState(0);
+  const pageSize = 20;
+
+  // 상품 목록 로드
+  const loadProducts = useCallback(async (page: number = 0) => {
+    try {
+      console.log("상품 목록 로드 시작:", { page, pageSize });
+      setLoading(true);
+      const response = await ProductService.getSellerProducts(page, pageSize);
+      console.log("상품 목록 로드 성공:", response);
+      setProducts(response.content || []);
+      setTotalPages(response.totalPages || 0);
+      setTotalElements(response.totalElements || 0);
+      setCurrentPage(page);
+    } catch (error: any) {
+      console.error("상품 목록 로드 실패:", error);
+      console.error("에러 상세:", error.response?.data);
+      
+      // 인증 에러인 경우
+      if (error.response?.status === 401) {
+        setErrorMessage("로그인이 필요합니다. 다시 로그인해주세요.");
+      } else if (error.response?.status === 403) {
+        setErrorMessage("판매자 권한이 필요합니다.");
+      } else {
+        setErrorMessage("상품 목록을 불러오는데 실패했습니다. 다시 시도해주세요.");
+      }
+      setShowErrorModal(true);
+    } finally {
+      setLoading(false);
+    }
+  }, [pageSize]);
+
+  // 카테고리 목록 로드
+  const loadCategories = useCallback(async () => {
+    try {
+      console.log("카테고리 로드 시작");
+      const categoryList = await ProductService.getCategories();
+      console.log("카테고리 로드 성공:", categoryList);
+      setCategories(categoryList);
+    } catch (error: any) {
+      console.error("카테고리 로드 실패:", error);
+      console.error("에러 상세:", error.response?.data);
+      setErrorMessage("카테고리를 불러오는데 실패했습니다.");
+      setShowErrorModal(true);
+      // 기본 카테고리 설정
+      setCategories([
+        { categoryId: 1, type: "FASHION", name: "패션" },
+        { categoryId: 2, type: "ELECTRONICS", name: "전자제품" },
+        { categoryId: 3, type: "SPORTS", name: "스포츠" },
+      ]);
+    }
+  }, []);
+
+  useEffect(() => {
+    // 인증 상태 확인
+    const token = localStorage.getItem("token");
+    const userType = localStorage.getItem("userType");
+    
+    console.log("인증 상태 확인:", { 
+      hasToken: !!token, 
+      userType,
+      token: token ? token.substring(0, 20) + "..." : null 
+    });
+    
+    if (!token) {
+      setErrorMessage("로그인이 필요합니다. 다시 로그인해주세요.");
+      setShowErrorModal(true);
+      return;
+    }
+    
+    if (userType !== "seller") {
+      setErrorMessage("판매자 권한이 필요합니다.");
+      setShowErrorModal(true);
+      return;
+    }
+    
+    loadProducts();
+    loadCategories();
+  }, [loadProducts, loadCategories]);
+
+  // 페이지네이션 핸들러
+  const handlePageChange = useCallback((page: number) => {
+    if (page >= 0 && page < totalPages) {
+      loadProducts(page);
+    }
+  }, [totalPages, loadProducts]);
+
+  // 페이지 번호 생성 (메모이제이션)
+  const pageNumbers = useMemo(() => {
+    const pages = [];
+    const maxVisible = 5;
+
+    let start = Math.max(0, currentPage - Math.floor(maxVisible / 2));
+    let end = Math.min(totalPages - 1, start + maxVisible - 1);
+
+    if (end - start + 1 < maxVisible) {
+      start = Math.max(0, end - maxVisible + 1);
+    }
+
+    for (let i = start; i <= end; i++) {
+      pages.push(i);
+    }
+
+    return pages;
+  }, [currentPage, totalPages]);
+
+  // 상품 등록/수정 (저장 상태 관리 및 알림)
+  const handleSaveProduct = useCallback(async (productData: CreateProductRequest) => {
+    if (isSaving) return; // 중복 클릭 방지
+    try {
+      setIsSaving(true);
+
+      if (editProduct) {
+        // 수정
+        const updateData: UpdateProductRequest = {
+          name: productData.name,
+          price: productData.price,
+          categoryId: productData.categoryId,
+          description: productData.description,
+          discountType: productData.discountType,
+          discountValue: productData.discountValue,
+          images: productData.images,
+          options: productData.options,
+        };
+        await ProductService.updateProduct(editProduct.productId, updateData);
+        setSuccessMessage("상품이 성공적으로 수정되었습니다.");
+      } else {
+        // 등록
+        await ProductService.createProduct(productData);
+        setSuccessMessage("상품이 성공적으로 등록되었습니다.");
+      }
+
+      setIsModalOpen(false);
+      setEditProduct(null);
+      loadProducts(currentPage); // 현재 페이지 유지하며 목록 새로고침
+      setShowSuccessModal(true);
+    } catch (error) {
+      console.error("상품 저장 실패:", error);
+      setErrorMessage("상품 저장에 실패했습니다. 다시 시도해주세요.");
+      setShowErrorModal(true);
+    } finally {
+      setIsSaving(false);
+    }
+  }, [editProduct, currentPage, loadProducts, isSaving]);
+
+  // 상품 삭제 확인 다이얼로그 열기
+  const handleDeleteProduct = useCallback((productId: number) => {
+    setProductToDelete(productId);
+    setDeleteWarningOpen(true);
+  }, []);
+
+  // 상품 삭제 실행
+  const confirmDeleteProduct = useCallback(async () => {
+    if (productToDelete) {
+      try {
+        await ProductService.deleteProduct(productToDelete);
+        setSuccessMessage("상품이 성공적으로 삭제되었습니다.");
+        loadProducts(currentPage); // 현재 페이지 유지하며 목록 새로고침
+        setDeleteWarningOpen(false);
+        setProductToDelete(null);
+        setShowSuccessModal(true);
+      } catch (error) {
+        console.error("상품 삭제 실패:", error);
+        setErrorMessage("상품 삭제에 실패했습니다. 다시 시도해주세요.");
+        setShowErrorModal(true);
+      }
+    }
+  }, [productToDelete, currentPage, loadProducts]);
+
+  // 상품 삭제 취소
+  const cancelDeleteProduct = useCallback(() => {
+    setDeleteWarningOpen(false);
+    setProductToDelete(null);
+  }, []);
+
+  // 상품 수정 모달 열기
+  const handleEditProduct = useCallback((product: ProductListItem) => {
+    setEditProduct(product);
+    setIsModalOpen(true);
+  }, []);
+
+  // 새 상품 등록 모달 열기
+  const handleNewProduct = useCallback(() => {
+    setEditProduct(null);
+    setIsModalOpen(true);
+  }, []);
+
+  return (
+    <ManagementContainer>
+      {/* 헤더 */}
+      <Header>
+        <div>
+          <Title>상품 관리</Title>
+          <p style={{ color: "#6b7280", marginTop: "8px" }}>
+            등록된 상품을 관리하고 새로운 상품을 추가하세요
+          </p>
+        </div>
+        <ActionButton variant="primary" onClick={handleNewProduct}>
+          <i className="fas fa-plus" style={{ marginRight: "8px" }}></i>
+          상품 등록
+        </ActionButton>
+      </Header>
+
+      {/* 상품 목록 */}
+      {loading ? (
+        <LoadingState>
+          <i className="fas fa-spinner fa-spin"></i>
+          상품 목록을 불러오는 중...
+        </LoadingState>
+      ) : (
+        <>
+          <TableContainer>
+            {products.length === 0 ? (
+              <EmptyState>
+                <EmptyIcon>
+                  <i className="fas fa-box-open"></i>
+                </EmptyIcon>
+                <div
+                  style={{
+                    fontSize: "1.125rem",
+                    fontWeight: 600,
+                    marginBottom: "8px",
+                  }}
+                >
+                  등록된 상품이 없습니다
+                </div>
+                <div style={{ marginBottom: "16px" }}>
+                  첫 번째 상품을 등록해보세요
+                </div>
+              </EmptyState>
+            ) : (
+              <Table>
+                <TableHeader>
+                  <tr>
+                    <TableHeaderCell>상품 정보</TableHeaderCell>
+                    <TableHeaderCell>가격</TableHeaderCell>
+                    <TableHeaderCell>스토어</TableHeaderCell>
+                    <TableHeaderCell>관심</TableHeaderCell>
+                    <TableHeaderCell style={{ textAlign: "right" }}>
+                      관리
+                    </TableHeaderCell>
+                  </tr>
+                </TableHeader>
+                <tbody>
+                  {products.map((product) => (
+                    <TableRow key={product.productId}>
+                      <TableCell>
+                        <ProductInfo>
+                          <ProductImage
+                            src={toUrl(product.mainImageUrl)}
+                            alt={product.name}
+                            onError={(e) => {
+                              e.currentTarget.src = toUrl(
+                                "images/common/no-image.png"
+                              );
+                            }}
+                          />
+                          <ProductDetails>
+                            <ProductName>{product.name}</ProductName>
+                            <ProductId>ID: {product.productId}</ProductId>
+                          </ProductDetails>
+                        </ProductInfo>
+                      </TableCell>
+                      <TableCell>
+                        <PriceInfo>
+                          <Price>₩{product.price.toLocaleString()}</Price>
+                          {product.discountPrice !== product.price && (
+                            <DiscountPrice>
+                              할인: ₩{product.discountPrice.toLocaleString()}
+                            </DiscountPrice>
+                          )}
+                        </PriceInfo>
+                      </TableCell>
+                      <TableCell>
+                        <div>
+                          <div
+                            style={{ fontSize: "0.875rem", color: "#1f2937" }}
+                          >
+                            {product.storeName}
+                          </div>
+                          <div
+                            style={{ fontSize: "0.75rem", color: "#6b7280" }}
+                          >
+                            ID: {product.storeId}
+                          </div>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <div
+                          style={{
+                            display: "flex",
+                            alignItems: "center",
+                            gap: "4px",
+                          }}
+                        >
+                          <i
+                            className="fas fa-heart"
+                            style={{ color: "#ef4444", fontSize: "0.875rem" }}
+                          ></i>
+                          <span style={{ fontSize: "0.875rem" }}>
+                            {product.wishNumber}
+                          </span>
+                        </div>
+                      </TableCell>
+                      <TableCell>
+                        <ActionButtons>
+                          <ActionButton
+                            variant="secondary"
+                            onClick={() => handleEditProduct(product)}
+                          >
+                            <i className="fas fa-edit"></i>
+                          </ActionButton>
+                          <ActionButton
+                            variant="danger"
+                            onClick={() => handleDeleteProduct(product.productId)}
+                          >
+                            <i className="fas fa-trash"></i>
+                          </ActionButton>
+                        </ActionButtons>
+                      </TableCell>
+                    </TableRow>
+                  ))}
+                </tbody>
+              </Table>
+            )}
+          </TableContainer>
+
+          {/* 페이지네이션 */}
+          {products.length > 0 && totalPages > 1 && (
+            <PaginationContainer>
+              <PaginationInfo>
+                총 {totalElements}개 상품 중 {currentPage * pageSize + 1}-
+                {Math.min((currentPage + 1) * pageSize, totalElements)}개 표시
+              </PaginationInfo>
+              <PaginationButtons>
+                <PaginationButton
+                  $disabled={currentPage === 0}
+                  onClick={() => handlePageChange(0)}
+                  disabled={currentPage === 0}
+                >
+                  <i className="fas fa-angle-double-left"></i>
+                </PaginationButton>
+                <PaginationButton
+                  $disabled={currentPage === 0}
+                  onClick={() => handlePageChange(currentPage - 1)}
+                  disabled={currentPage === 0}
+                >
+                  <i className="fas fa-angle-left"></i>
+                </PaginationButton>
+
+                <PageNumbers>
+                  {pageNumbers.map((page) => (
+                    <PaginationButton
+                      key={page}
+                      $active={page === currentPage}
+                      onClick={() => handlePageChange(page)}
+                    >
+                      {page + 1}
+                    </PaginationButton>
+                  ))}
+                </PageNumbers>
+
+                <PaginationButton
+                  $disabled={currentPage === totalPages - 1}
+                  onClick={() => handlePageChange(currentPage + 1)}
+                  disabled={currentPage === totalPages - 1}
+                >
+                  <i className="fas fa-angle-right"></i>
+                </PaginationButton>
+                <PaginationButton
+                  $disabled={currentPage === totalPages - 1}
+                  onClick={() => handlePageChange(totalPages - 1)}
+                  disabled={currentPage === totalPages - 1}
+                >
+                  <i className="fas fa-angle-double-right"></i>
+                </PaginationButton>
+              </PaginationButtons>
+            </PaginationContainer>
+          )}
+        </>
+      )}
+
+      {/* 상품 등록/수정 모달 */}
+      <ProductModal
+        isOpen={isModalOpen}
+        onClose={() => {
+          setIsModalOpen(false);
+          setEditProduct(null);
+        }}
+        onSave={handleSaveProduct}
+        editProduct={editProduct}
+        categories={categories}
+      />
+
+      {/* 상품 삭제 확인 모달 */}
+      <Warning
+        open={deleteWarningOpen}
+        title="상품 삭제"
+        message="정말로 이 상품을 삭제하시겠습니까? 삭제된 상품은 복구할 수 없습니다."
+        onConfirm={confirmDeleteProduct}
+        onCancel={cancelDeleteProduct}
+      />
+
+      {/* 성공 알림 모달 */}
+      <Warning
+        open={showSuccessModal}
+        title="성공"
+        message={successMessage}
+        onConfirm={() => setShowSuccessModal(false)}
+        onCancel={() => setShowSuccessModal(false)}
+      />
+
+      {/* 오류 알림 모달 */}
+      <Warning
+        open={showErrorModal}
+        title="오류"
+        message={errorMessage}
+        onConfirm={() => setShowErrorModal(false)}
+        onCancel={() => setShowErrorModal(false)}
+      />
+    </ManagementContainer>
+  );
+};
+
+export default SellerProductManagePage;

--- a/src/types/order.ts
+++ b/src/types/order.ts
@@ -1,6 +1,8 @@
 export interface PaymentItem {
   id: string;
   productName: string;
+  gender?: "MEN" | "WOMEN" | "UNISEX"; // 성별 정보 추가
+  color?: string;                       // 색상 정보 추가
   size: string;
   discountPrice: number;
   productPrice: number;

--- a/src/types/products.ts
+++ b/src/types/products.ts
@@ -56,20 +56,160 @@ export interface CreateProductRequest {
   name: string;
   price: number;
   categoryId: number;
-  description: string;
-  discountType?: "RATE_DISCOUNT" | "FIXED_DISCOUNT" | "NONE";
+  description: string; // 필수로 변경
+  discountType?: "RATE_DISCOUNT" | "FIXED_DISCOUNT" | "NONE"; // API 명세에 맞게 수정
   discountValue?: number;
-  images: Array<{
-    url: string;
-    type: "MAIN" | "DETAIL";
-  }>;
-  options: Array<{
-    gender: "MEN" | "WOMEN" | "UNISEX";
-    size: string;
-    color: string;
-    stock: number;
-  }>;
+  images: ProductImageRequest[];
+  options: ProductOptionRequest[];
 }
+
+export interface ProductImageRequest {
+  imageId?: number; // 수정 시 사용
+  url: string;
+  isMain: boolean;
+  displayOrder: number;
+  file?: File; // 파일 브라우저용 추가
+  type?: "MAIN" | "DETAIL"; // 이미지 타입 추가
+}
+
+export interface ProductOptionRequest {
+  optionId?: number; // 수정 시 사용
+  gender: "MEN" | "WOMEN" | "UNISEX"; // 성별 추가
+  color: ColorType;
+  size: SizeType;
+  stock: number;
+}
+
+// 색상 타입 정의
+export type ColorType =
+  | "WHITE"
+  | "SILVER"
+  | "LIGHT_GRAY"
+  | "GRAY"
+  | "DARK_GRAY"
+  | "BLACK"
+  | "RED"
+  | "DEEP_RED"
+  | "BURGUNDY"
+  | "PALE_PINK"
+  | "LIGHT_PINK"
+  | "PINK"
+  | "DARK_PINK"
+  | "PEACH"
+  | "LIGHT_ORANGE"
+  | "ORANGE"
+  | "DARK_ORANGE"
+  | "IVORY"
+  | "LIGHT_YELLOW"
+  | "YELLOW"
+  | "MUSTARD"
+  | "GOLD"
+  | "LIME"
+  | "LIGHT_GREEN"
+  | "GREEN"
+  | "OLIVE_GREEN"
+  | "KHAKI"
+  | "DARK_GREEN"
+  | "MINT"
+  | "SKY_BLUE"
+  | "BLUE"
+  | "DARK_BLUE"
+  | "NAVY"
+  | "DARK_NAVY"
+  | "LAVENDER"
+  | "PURPLE"
+  | "LIGHT_BROWN"
+  | "BROWN"
+  | "DARK_BROWN"
+  | "SAND"
+  | "BEIGE"
+  | "DARK_BEIGE"
+  | "OTHER_COLORS"
+  | "KHAKI_BEIGE";
+
+// 사이즈 타입 정의
+export type SizeType =
+  | "SIZE_230"
+  | "SIZE_235"
+  | "SIZE_240"
+  | "SIZE_245"
+  | "SIZE_250"
+  | "SIZE_255"
+  | "SIZE_260"
+  | "SIZE_265"
+  | "SIZE_270"
+  | "SIZE_275"
+  | "SIZE_280"
+  | "SIZE_285"
+  | "SIZE_290"
+  | "SIZE_295"
+  | "SIZE_300";
+
+// 색상과 사이즈 매핑 객체
+export const COLOR_LABELS: Record<ColorType, string> = {
+  WHITE: "화이트",
+  SILVER: "실버",
+  LIGHT_GRAY: "라이트 그레이",
+  GRAY: "그레이",
+  DARK_GRAY: "다크 그레이",
+  BLACK: "블랙",
+  RED: "레드",
+  DEEP_RED: "딥 레드",
+  BURGUNDY: "버건디",
+  PALE_PINK: "페일 핑크",
+  LIGHT_PINK: "라이트 핑크",
+  PINK: "핑크",
+  DARK_PINK: "다크 핑크",
+  PEACH: "피치",
+  LIGHT_ORANGE: "라이트 오렌지",
+  ORANGE: "오렌지",
+  DARK_ORANGE: "다크 오렌지",
+  IVORY: "아이보리",
+  LIGHT_YELLOW: "라이트 옐로우",
+  YELLOW: "옐로우",
+  MUSTARD: "머스타드",
+  GOLD: "골드",
+  LIME: "라임",
+  LIGHT_GREEN: "라이트 그린",
+  GREEN: "그린",
+  OLIVE_GREEN: "올리브 그린",
+  KHAKI: "카키",
+  DARK_GREEN: "다크 그린",
+  MINT: "민트",
+  SKY_BLUE: "스카이 블루",
+  BLUE: "블루",
+  DARK_BLUE: "다크 블루",
+  NAVY: "네이비",
+  DARK_NAVY: "다크 네이비",
+  LAVENDER: "라벤더",
+  PURPLE: "퍼플",
+  LIGHT_BROWN: "라이트 브라운",
+  BROWN: "브라운",
+  DARK_BROWN: "다크 브라운",
+  SAND: "샌드",
+  BEIGE: "베이지",
+  DARK_BEIGE: "다크 베이지",
+  OTHER_COLORS: "기타",
+  KHAKI_BEIGE: "카키 베이지",
+};
+
+export const SIZE_LABELS: Record<SizeType, string> = {
+  SIZE_230: "230",
+  SIZE_235: "235",
+  SIZE_240: "240",
+  SIZE_245: "245",
+  SIZE_250: "250",
+  SIZE_255: "255",
+  SIZE_260: "260",
+  SIZE_265: "265",
+  SIZE_270: "270",
+  SIZE_275: "275",
+  SIZE_280: "280",
+  SIZE_285: "285",
+  SIZE_290: "290",
+  SIZE_295: "295",
+  SIZE_300: "300",
+};
 
 export interface UpdateProductRequest {
   name?: string;
@@ -78,6 +218,8 @@ export interface UpdateProductRequest {
   description?: string;
   discountType?: "RATE_DISCOUNT" | "FIXED_DISCOUNT" | "NONE";
   discountValue?: number;
+  images?: ProductImageRequest[];
+  options?: ProductOptionRequest[];
 }
 
 export interface CategoryFilterParams {
@@ -88,6 +230,21 @@ export interface CategoryFilterParams {
   size?: number; // 페이지 크기 (기본값: 20)
   storeId?: number; // 스토어 ID (선택적)
   sort?: string; // 정렬 방식 (latest/popular, 기본값: latest)
+}
+
+export interface Store {
+  storeId: number;
+  storeName: string;
+}
+
+export interface SellerStore {
+  storeId: number;
+  sellerId: number;
+  storeName: string;
+  description: string;
+  logo: string;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface CategoryModalProps {


### PR DESCRIPTION
# 🛍️ Pull Request

## 📋 Summary
<!-- 이 PR이 무엇을 하는지 한 줄로 요약해주세요 -->
구글/카카오 소셜 로그인 기능을 백엔드 API와 연동하여 구현

**Type**
- [x] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ♻️ Refactor
- [ ] 🎨 UI/UX
- [ ] 📝 Docs
- [ ] 🔧 Chore

---

## 🎯 What & Why
### 무엇을 했나요?
<!-- 구현한 기능이나 수정한 내용을 설명해주세요 -->
- 기존 로그인 페이지의 소셜 로그인 버튼을 백엔드 API와 연동
- 소셜 로그인 성공 후 콜백 처리 페이지 구현
- 소셜 로그인 관련 API 서비스 클래스 추가
- React Router의 useSearchParams를 활용한 URL 파라미터 처리

### 왜 필요했나요?
<!-- 이 작업이 필요한 이유나 해결하려는 문제를 설명해주세요 -->

- 기존 소셜 로그인 버튼이 실제 기능 없이 console.log만 출력하는 상태였음
- 백엔드에서 OAuth2 소셜 로그인 API가 구현되었으나 프론트엔드 연동이 필요했음
- 사용자 편의성을 위해 소셜 계정으로 간편 로그인 기능 제공

---

## 🔧 How (구현 방법)
### 주요 변경사항
- `src/pages/auth/LoginPage.tsx`: 소셜 로그인 핸들러 함수 추가
- `src/pages/auth/SocialCallbackPage.tsx`: 소셜 로그인 콜백 처리 페이지 신규 생성
- `src/App.tsx`: 소셜 콜백 페이지 라우트 추가
- `src/api/socialAuthService.ts`: 소셜 로그인 관련 API 서비스 클래스 신규 생성


### 기술적 접근
- OAuth2 표준 플로우에 따른 리다이렉트 방식 구현
- React Router의 useSearchParams 훅을 활용한 URL 파라미터 안전한 처리
- AuthContext를 통한 통합된 인증 상태 관리
- 에러 처리 및 사용자 피드백 개선

---

## 🧪 Testing
### 테스트 방법
<!-- 어떻게 테스트했는지 설명해주세요 -->
1. 로그인 페이지에서 "구글로 로그인" 버튼 클릭
2. 구글 OAuth2 인증 페이지로 리다이렉트 확인
3. 구글 계정으로 로그인 후 콜백 페이지로 리다이렉트 확인
4. JWT 토큰과 사용자 정보 파싱 및 로그인 처리 확인
5. 홈페이지로 자동 리다이렉트 및 로그인 상태 확인


### 확인 사항
- [x] 기능 정상 동작 확인
- [x] 기존 기능 영향 없음
- [x] 예외 케이스 테스트 완료 (토큰 누락, 에러 파라미터 등)

---

## 📎 관련 이슈 / 문서
- 관련 이슈: 없음
- 지라 백로그: [https://sesac-springboot.atlassian.net/browse/MYCE-185](url)
---

## 💬 Additional Notes
<!-- 리뷰어가 알아야 할 추가 정보나 주의사항 -->

- 백엔드에서 OAuth2 리다이렉트 URL 설정 필요: `http://localhost:3000/auth/callback`
- 현재 구글, 카카오 소셜 로그인 지원 (네이버는 백엔드에서 지원하지만 UI 미구현)
- Authorization Code 플로우는 백엔드에서 JWT 토큰으로 변환하여 전달하는 방식 사용
- 프로덕션 배포 시 환경변수 `REACT_APP_API_URL` 설정 필요

---

## ✅ Checklist
- [x] 코드 리뷰 준비 완료
- [x] 테스트 완료
- [x] 불필요한 로그 제거
